### PR TITLE
Fix filesystem path loading

### DIFF
--- a/packages/beasties-webpack-plugin/src/index.js
+++ b/packages/beasties-webpack-plugin/src/index.js
@@ -175,7 +175,7 @@ export default class BeastiesWebpackPlugin extends Beasties {
 
     if (!sheet) {
       try {
-        sheet = await this.readFile(this.compilation, filename)
+        sheet = await this.readFile(filename)
         this.logger.warn(
           `Stylesheet "${relativePath}" not found in assets, but a file was located on disk.${
             this.options.pruneSource

--- a/packages/beasties-webpack-plugin/test/fixtures/fs-access/dist/style.css
+++ b/packages/beasties-webpack-plugin/test/fixtures/fs-access/dist/style.css
@@ -1,0 +1,1 @@
+div.foo{color:red}

--- a/packages/beasties-webpack-plugin/test/fixtures/fs-access/index.html
+++ b/packages/beasties-webpack-plugin/test/fixtures/fs-access/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <link rel="stylesheet" href="./style.css"/>
+    <title>Access external stylesheet from FS</title>
+  </head>
+  <body>
+    <div class="foo">
+      <h1>Access external stylesheet from FS</h1>
+    </div>
+  </body>
+</html>

--- a/packages/beasties-webpack-plugin/test/index.test.ts
+++ b/packages/beasties-webpack-plugin/test/index.test.ts
@@ -201,7 +201,7 @@ describe('options', () => {
 describe('accessing file system', () => {
   it('works', async () => {
     const output = await compileToHtml('fs-access', configure, {
-      path: './dist/',
+      path: 'dist',
       publicPath: '',
     })
     expect(output.html).toMatch(/\.foo/)

--- a/packages/beasties-webpack-plugin/test/index.test.ts
+++ b/packages/beasties-webpack-plugin/test/index.test.ts
@@ -197,3 +197,13 @@ describe('options', () => {
     })
   })
 })
+
+describe('accessing file system', () => {
+  it('works', async () => {
+    const output = await compileToHtml('fs-access', configure, {
+      path: './dist/',
+      publicPath: '',
+    })
+    expect(output.html).toMatch(/\.foo/)
+  })
+})


### PR DESCRIPTION
Fixes #29 

I can't fully test, since it seems that some of the tests are broken on Windows as they expect a unix-style path, but I can confirm that it resolves the immediate issue. `Beasties.readFile()` only takes a single argument, which is the filename.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of CSS assets within the plugin.
	- Enhanced logging for better traceability of asset management.
	- Added a new HTML fixture for testing external stylesheet access.

- **Bug Fixes**
	- Updated error handling for missing stylesheets, including clearer warning messages.

- **Tests**
	- Introduced a new test suite for verifying file system access functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->