### PR TITLE
fix: improve handling of pseudo classes and elements

### DIFF
--- a/packages/beasties/src/index.ts
+++ b/packages/beasties/src/index.ts
@@ -26,8 +26,7 @@ import { applyMarkedSelectors, markOnly, parseStylesheet, serializeStylesheet, v
 import { createDocument, serializeDocument } from './dom'
 import { createLogger, isSubpath } from './util'
 
-const removePseudoElementsPattern = /(?<!\\)::?[a-z-]+(?![a-z-(])/gi
-const cleanEmptyNotPattern = /::?not\(\s*\)/g
+const removePseudoClassesAndElementsPattern = /(?<!\\)::?[a-z-]+(?:\(.+\))?/gi
 const removeTrailingCommasPattern = /\(\s*,|,\s*\)/g
 
 export default class Beasties {
@@ -678,8 +677,7 @@ export default class Beasties {
     }
 
     normalizedSelector = sel
-      .replace(removePseudoElementsPattern, '')
-      .replace(cleanEmptyNotPattern, '')
+      .replace(removePseudoClassesAndElementsPattern, '')
       .replace(removeTrailingCommasPattern, match => (match.includes('(') ? '(' : ')'))
       .trim() as string
 

--- a/packages/beasties/test/__snapshots__/beasties.test.ts.snap
+++ b/packages/beasties/test/__snapshots__/beasties.test.ts.snap
@@ -123,3 +123,16 @@ exports[`beasties > skip invalid path 1`] = `
 </html>
 "
 `;
+
+exports[`beasties > works with pseudo classes and elements 1`] = `
+"<html data-beasties-container>
+  <head>
+    <style>h1{color:blue}h1:has(+ p){margin-bottom:0}p{color:purple}p:only-child{color:fuchsia}input:where(:not([readonly])):where(:active, :focus, :focus-visible, [data-focused]){color:blue}</style><link rel="preload" href="/style.css" as="style">
+  </head>
+  <body>
+    <h1>Hello World!</h1>
+    <p>This is a paragraph</p>
+    <input type="text">
+  <link rel="stylesheet" href="/style.css"></body>
+</html>"
+`;


### PR DESCRIPTION
Closes #52

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR improves the handling of pseudo classes and elements in the Beasties library by updating the regex patterns used for normalization.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Test
    participant Beasties
    participant CSS Parser

    Test->>Beasties: process(HTML with stylesheet)
    Note over Beasties: New pattern added for<br/>pseudo-classes/elements

    Beasties->>CSS Parser: Parse CSS from style.css
    CSS Parser-->>Beasties: Return CSS rules

    Note over Beasties: Remove pseudo-classes/elements<br/>from selectors during normalization
    
    Beasties->>Beasties: normalizedSelector()<br/>Remove :pseudo-classes<br/>Remove ::pseudo-elements
    
    Beasties-->>Test: Return processed HTML with:<br/>- Original pseudo selectors preserved<br/>- Inlined styles in head
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/danielroe/beasties/pull/58/files#diff-4235a696ef2eaf34ccb14e2449cf3ef61d531df3e462f6ffe11c4b516f280f25>packages/beasties/src/index.ts</a></td><td>Updated regex pattern to handle pseudo classes and elements.</td></tr>
<tr><td><a href=https://github.com/danielroe/beasties/pull/58/files#diff-849e319a3a7f331b4d494ee9ca7d1e87800e7cfe48ec30be99f440f809225397>packages/beasties/test/__snapshots__/beasties.test.ts.snap</a></td><td>Added snapshot for new test case involving pseudo classes and elements.</td></tr>
<tr><td><a href=https://github.com/danielroe/beasties/pull/58/files#diff-85d39184055aba70288d5466be440921fe7bc8cda59fece2a61ae7dcb03c2b87>packages/beasties/test/beasties.test.ts</a></td><td>Added a test case to verify the handling of pseudo classes and elements.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.ts`, `.snap`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced CSS selector processing to support both pseudo-classes and pseudo-elements.
	- Improved normalization of CSS selectors for better stylesheet handling.

- **Tests**
	- Introduced a new test case to verify handling of CSS pseudo-classes and pseudo-elements, ensuring correct processing and logger behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->