### PR TITLE
feat: new preload strategy `swap-low`

### DIFF
--- a/packages/beasties/README.md
+++ b/packages/beasties/README.md
@@ -240,7 +240,7 @@ Note: <kbd>JS</kbd> indicates a strategy requiring JavaScript (falls back to `<n
 - **"media":** Load stylesheets asynchronously by adding `media="not x"` and removing once loaded. <kbd>JS</kbd>
 - **"swap":** Convert stylesheet links to preloads that swap to `rel="stylesheet"` once loaded ([details](https://www.filamentgroup.com/lab/load-css-simpler/#the-code)). <kbd>JS</kbd>
 - **"swap-high":** Use `<link rel="alternate stylesheet preload">` and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-high.html)). <kbd>JS</kbd>
-- **"swap-low":** Use `<link rel="alternate stylesheet">` (no `preload` in `rel` here!) and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-low.html)). It ensures lowest priority compare to `swap-high`. <kbd>JS</kbd>
+- **"swap-low":** Use `<link rel="alternate stylesheet">` (no `preload` in `rel` here!) and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-low.html)). It ensures lowest priority compared to `swap` and `swap-high`. <kbd>JS</kbd>
 - **"js":** Inject an asynchronous CSS loader similar to [LoadCSS](https://github.com/filamentgroup/loadCSS) and use it to load stylesheets. <kbd>JS</kbd>
 - **"js-lazy":** Like `"js"`, but the stylesheet is disabled until fully loaded.
 - **false:** Disables adding preload tags.

--- a/packages/beasties/README.md
+++ b/packages/beasties/README.md
@@ -240,11 +240,12 @@ Note: <kbd>JS</kbd> indicates a strategy requiring JavaScript (falls back to `<n
 - **"media":** Load stylesheets asynchronously by adding `media="not x"` and removing once loaded. <kbd>JS</kbd>
 - **"swap":** Convert stylesheet links to preloads that swap to `rel="stylesheet"` once loaded ([details](https://www.filamentgroup.com/lab/load-css-simpler/#the-code)). <kbd>JS</kbd>
 - **"swap-high":** Use `<link rel="alternate stylesheet preload">` and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-high.html)). <kbd>JS</kbd>
+- **"swap-low":** Use `<link rel="alternate stylesheet">` (no `preload` in `rel` here!) and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-low.html)). It ensures lowest priority compare to `swap-high`. <kbd>JS</kbd>
 - **"js":** Inject an asynchronous CSS loader similar to [LoadCSS](https://github.com/filamentgroup/loadCSS) and use it to load stylesheets. <kbd>JS</kbd>
 - **"js-lazy":** Like `"js"`, but the stylesheet is disabled until fully loaded.
 - **false:** Disables adding preload tags.
 
-Type: (default | `"body"` | `"media"` | `"swap"` | `"swap-high"` | `"js"` | `"js-lazy"`)
+Type: (default | `"body"` | `"media"` | `"swap"` | `"swap-high"` | `"swap-low"` | `"js"` | `"js-lazy"`)
 
 ## Similar Libraries
 

--- a/packages/beasties/src/index.d.ts
+++ b/packages/beasties/src/index.d.ts
@@ -47,7 +47,7 @@ export interface Options {
   pruneSource?: boolean
   mergeStylesheets?: boolean
   additionalStylesheets?: string[]
-  preload?: 'body' | 'media' | 'swap' | 'swap-high' | 'js' | 'js-lazy'
+  preload?: 'body' | 'media' | 'swap' | 'swap-high' | 'swap-low' | 'js' | 'js-lazy'
   noscriptFallback?: boolean
   inlineFonts?: boolean
   preloadFonts?: boolean

--- a/packages/beasties/src/index.ts
+++ b/packages/beasties/src/index.ts
@@ -310,6 +310,13 @@ export default class Beasties {
         link.setAttribute('onload', `this.title='';this.rel='stylesheet'`)
         noscriptFallback = true
       }
+      else if (preloadMode === 'swap-low') {
+        // @see http://filamentgroup.github.io/loadCSS/test/new-low.html
+        link.setAttribute('rel', 'alternate stylesheet')
+        link.setAttribute('title', 'styles')
+        link.setAttribute('onload', `this.title='';this.rel='stylesheet'`)
+        noscriptFallback = true
+      }
       else if (preloadMode === 'swap') {
         link.setAttribute('onload', 'this.rel=\'stylesheet\'')
         noscriptFallback = true

--- a/packages/beasties/src/types.ts
+++ b/packages/beasties/src/types.ts
@@ -10,7 +10,7 @@ import type { Logger, LogLevel } from './util'
  * - **"media":** Load stylesheets asynchronously by adding `media="not x"` and removing once loaded. <kbd>JS</kbd>
  * - **"swap":** Convert stylesheet links to preloads that swap to `rel="stylesheet"` once loaded ([details](https://www.filamentgroup.com/lab/load-css-simpler/#the-code)). <kbd>JS</kbd>
  * - **"swap-high":** Use `<link rel="alternate stylesheet preload">` and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-high.html)). <kbd>JS</kbd>
- * - **"swap-low":** Use `<link rel="alternate stylesheet">` (no `preload` in `rel` here!) and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-low.html)). It ensures lowest priority compare to `swap-high`. <kbd>JS</kbd>
+ * - **"swap-low":** Use `<link rel="alternate stylesheet">` (no `preload` in `rel` here!) and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-low.html)). It ensures lowest priority compared to `swap` and `swap-high`. <kbd>JS</kbd>
  * - **"js":** Inject an asynchronous CSS loader similar to [LoadCSS](https://github.com/filamentgroup/loadCSS) and use it to load stylesheets. <kbd>JS</kbd>
  * - **"js-lazy":** Like `"js"`, but the stylesheet is disabled until fully loaded.
  * - **false:** Disables adding preload tags.

--- a/packages/beasties/src/types.ts
+++ b/packages/beasties/src/types.ts
@@ -10,11 +10,12 @@ import type { Logger, LogLevel } from './util'
  * - **"media":** Load stylesheets asynchronously by adding `media="not x"` and removing once loaded. <kbd>JS</kbd>
  * - **"swap":** Convert stylesheet links to preloads that swap to `rel="stylesheet"` once loaded ([details](https://www.filamentgroup.com/lab/load-css-simpler/#the-code)). <kbd>JS</kbd>
  * - **"swap-high":** Use `<link rel="alternate stylesheet preload">` and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-high.html)). <kbd>JS</kbd>
+ * - **"swap-low":** Use `<link rel="alternate stylesheet">` (no `preload` in `rel` here!) and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-low.html)). It ensures lowest priority compare to `swap-high`. <kbd>JS</kbd>
  * - **"js":** Inject an asynchronous CSS loader similar to [LoadCSS](https://github.com/filamentgroup/loadCSS) and use it to load stylesheets. <kbd>JS</kbd>
  * - **"js-lazy":** Like `"js"`, but the stylesheet is disabled until fully loaded.
  * - **false:** Disables adding preload tags.
  */
-type PreloadStrategy = 'body' | 'media' | 'swap' | 'swap-high' | 'js' | 'js-lazy'
+type PreloadStrategy = 'body' | 'media' | 'swap' | 'swap-high' | 'swap-low' | 'js' | 'js-lazy'
 
 /**
  * Controls which keyframes rules are inlined.

--- a/packages/beasties/test/__snapshots__/beasties.test.ts.snap
+++ b/packages/beasties/test/__snapshots__/beasties.test.ts.snap
@@ -188,3 +188,29 @@ exports[`preload modes > should use "swap" preload mode correctly 1`] = `
       </html>
     "
 `;
+
+exports[`preload modes > should use "swap-high" preload mode correctly 1`] = `
+"
+      <html data-beasties-container>
+        <head>
+          <style>h1{color:blue}</style><link rel="alternate stylesheet preload" href="/style.css" title="styles" onload="this.title='';this.rel='stylesheet'"><noscript><link rel="stylesheet" href="/style.css"></noscript>
+        </head>
+        <body>
+          <h1>Hello World!</h1>
+        </body>
+      </html>
+    "
+`;
+
+exports[`preload modes > should use "swap-low" preload mode correctly 1`] = `
+"
+      <html data-beasties-container>
+        <head>
+          <style>h1{color:blue}</style><link rel="alternate stylesheet" href="/style.css" title="styles" onload="this.title='';this.rel='stylesheet'"><noscript><link rel="stylesheet" href="/style.css"></noscript>
+        </head>
+        <body>
+          <h1>Hello World!</h1>
+        </body>
+      </html>
+    "
+`;

--- a/packages/beasties/test/beasties.test.ts
+++ b/packages/beasties/test/beasties.test.ts
@@ -405,4 +405,56 @@ describe('preload modes', () => {
     expect(result).not.toContain('<noscript>')
     expect(result).toMatchSnapshot()
   })
+
+  it('should use "swap-low" preload mode correctly', async () => {
+    const beasties = new Beasties({
+      reduceInlineStyles: false,
+      path: '/',
+      preload: 'swap-low',
+    })
+    const assets: Record<string, string> = {
+      '/style.css': 'h1 { color: blue; }',
+    }
+    beasties.readFile = filename => assets[filename.replace(/^\w:/, '').replace(/\\/g, '/')]!
+    const result = await beasties.process(`
+      <html>
+        <head>
+          <link rel="stylesheet" href="/style.css">
+        </head>
+        <body>
+          <h1>Hello World!</h1>
+        </body>
+      </html>
+    `)
+    expect(result).toContain('<style>h1{color:blue}</style>')
+    expect(result).toContain(`<link rel="alternate stylesheet" href="/style.css" title="styles" onload="this.title='';this.rel='stylesheet'">`)
+    expect(result).toContain('<noscript><link rel="stylesheet" href="/style.css"></noscript>')
+    expect(result).toMatchSnapshot()
+  })
+
+  it('should use "swap-high" preload mode correctly', async () => {
+    const beasties = new Beasties({
+      reduceInlineStyles: false,
+      path: '/',
+      preload: 'swap-high',
+    })
+    const assets: Record<string, string> = {
+      '/style.css': 'h1 { color: blue; }',
+    }
+    beasties.readFile = filename => assets[filename.replace(/^\w:/, '').replace(/\\/g, '/')]!
+    const result = await beasties.process(`
+      <html>
+        <head>
+          <link rel="stylesheet" href="/style.css">
+        </head>
+        <body>
+          <h1>Hello World!</h1>
+        </body>
+      </html>
+    `)
+    expect(result).toContain('<style>h1{color:blue}</style>')
+    expect(result).toContain(`<link rel="alternate stylesheet preload" href="/style.css" title="styles" onload="this.title='';this.rel='stylesheet'">`)
+    expect(result).toContain('<noscript><link rel="stylesheet" href="/style.css"></noscript>')
+    expect(result).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
`swap-low` uses `rel="alternate stylesheet"` (instead of `rel="alternate stylesheet preload"` used by `swap-high`) to ensure the lowest priority.

See https://filamentgroup.github.io/loadCSS/test/new-low.html

---

This was originally implemented in https://github.com/GoogleChromeLabs/critters/pull/101, but Google Chrome Teams simply ignored my PR for three years (Just a typical tradition of how Google Chrome Teams treats open-source contributions as always) and simply closed it as they archive the repo.

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR introduces a new preload strategy called `swap-low`, which uses `rel="alternate stylesheet"` to ensure the lowest priority for stylesheets. It updates the README, TypeScript definitions, and adds tests for the new strategy.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant Beasties
    participant StylesheetLink

    Browser->>Beasties: Process HTML with stylesheet
    
    alt preload="swap-low"
        Beasties->>StylesheetLink: Set rel="alternate stylesheet"
        Beasties->>StylesheetLink: Set title="styles"
        Beasties->>StylesheetLink: Add onload handler
        StylesheetLink-->>Browser: Load stylesheet with lowest priority
        
        Note over StylesheetLink: Once loaded
        StylesheetLink->>StylesheetLink: Clear title
        StylesheetLink->>StylesheetLink: Set rel="stylesheet"
    end

    Beasties->>Browser: Return processed HTML
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/danielroe/beasties/pull/72/files#diff-5214e88610c55c1c8974c092484a4457b07cb35736572deee34e8b86ae56f3d2>packages/beasties/README.md</a></td><td>Added documentation for the new <code>swap-low</code> preload strategy.</td></tr>
<tr><td><a href=https://github.com/danielroe/beasties/pull/72/files#diff-71a1c8cd5b1c38fdf915da0408ea418f55fdfd52ec6064c89e2a44d28a1c5e9b>packages/beasties/src/index.d.ts</a></td><td>Updated TypeScript definitions to include <code>swap-low</code> in the preload options.</td></tr>
<tr><td><a href=https://github.com/danielroe/beasties/pull/72/files#diff-4235a696ef2eaf34ccb14e2449cf3ef61d531df3e462f6ffe11c4b516f280f25>packages/beasties/src/index.ts</a></td><td>Implemented the logic for the <code>swap-low</code> preload strategy in the Beasties class.</td></tr>
<tr><td><a href=https://github.com/danielroe/beasties/pull/72/files#diff-3cd6e5ab38877eee8d674444475b8ed702b580f8bda7af921cac729f0f413b18>packages/beasties/src/types.ts</a></td><td>Updated type definitions to include <code>swap-low</code> in the PreloadStrategy type.</td></tr>
<tr><td><a href=https://github.com/danielroe/beasties/pull/72/files#diff-849e319a3a7f331b4d494ee9ca7d1e87800e7cfe48ec30be99f440f809225397>packages/beasties/test/__snapshots__/beasties.test.ts.snap</a></td><td>Added snapshot for the <code>swap-low</code> preload mode test.</td></tr>
<tr><td><a href=https://github.com/danielroe/beasties/pull/72/files#diff-85d39184055aba70288d5466be440921fe7bc8cda59fece2a61ae7dcb03c2b87>packages/beasties/test/beasties.test.ts</a></td><td>Added unit tests to verify the behavior of the <code>swap-low</code> preload mode.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.md`, `.ts`, `.snap`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->






