### PR TITLE
fix(beasties): support valid combinator chaining

### DIFF
--- a/packages/beasties/test/parse.test.ts
+++ b/packages/beasties/test/parse.test.ts
@@ -16,6 +16,7 @@ describe('selector normalisation', () => {
         </body>
       </html>
     `)
+
     expect(result.replace(/^ {4}/gm, '')).toMatchInlineSnapshot(`
       "
         <html data-beasties-container>
@@ -30,5 +31,46 @@ describe('selector normalisation', () => {
       "
     `)
     expect(console.warn).not.toBeCalled()
+  })
+
+  it('should preserve valid combinator chains', async () => {
+    const warnSpy = vi.spyOn(console, 'warn')
+    const beasties = new Beasties()
+    const html = `
+      <html><head>
+        <style>
+          /* Child + general sibling */
+          .form-floating>~label { color:red }
+          /* Child + adjacent sibling */
+          .btn-group>+.btn { color:blue }
+          /* Lobotomized owl */
+          .lobot>*+* { margin:0 }
+          /* Mixed sibling chains */
+          .foo~+span { color:aqua }
+          .bar+~div { color:salmon }
+          /* Sibling then child */
+          .baz~>h1 { font-weight:bold }
+          .qux+>p { text-align:center }
+        </style>
+      </head><body>
+        <div class="form-floating"><input/><label>F</label></div>
+        <div class="btn-group"><button></button><button class="btn">B</button></div>
+        <div class="lobot"><span></span><b></b></div>
+        <div class="foo"></div><em></em><span></span>
+        <div class="bar"></div><i></i><div></div>
+        <div class="baz"></div><div><h1>Header</h1></div>
+        <div class="qux"></div><div><p>Para</p></div>
+      </body></html>
+    `
+    const out = await beasties.process(html)
+
+    expect(out).toContain('.form-floating>~label{color:red}')
+    expect(out).toContain('.btn-group>+.btn{color:blue}')
+    expect(out).toContain('.lobot>*+*{margin:0}')
+    expect(out).toContain('.foo~+span{color:aqua}')
+    expect(out).toContain('.bar+~div{color:salmon}')
+    expect(out).toContain('.baz~>h1{font-weight:bold}')
+    expect(out).toContain('.qux+>p{text-align:center}')
+    expect(warnSpy).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
- normalizeCssSelector now handles >~, >+, ~>, etc. correctly
- added tests for all valid combinator chains

fixes a warning that is most commonly seen when inlining critical CSS in an angular project with bootstrap installed:

▲ [WARNING] 4 rules skipped due to selector errors:
  .form-floating>~label -> Did not expect successive traversals.
  .btn-group>+.btn -> Did not expect successive traversals.
  .btn-group>+.btn -> Did not expect successive traversals.
  .btn-group-vertical>+.btn -> Did not expect successive traversals.



Minimal reproduction to see improvement:

import Beasties from 'beasties';

async function run() {
  const html = `
    <html><head>
      <style>
        .form-floating>~label { color: red; }
      </style>
    </head><body>
      <div class="form-floating"><input/><label>Foo</label></div>
    </body></html>
  `;

  const beast = new Beasties({ logLevel: 'warn' });
  const out = await beast.process(html);
  console.log(out);
}

run();



before this PR:

1 rules skipped due to selector errors:
  .form-floating>~label -> Did not expect successive traversals.
Merging inline stylesheets into a single <style> tag skipped, no inline stylesheets to merge


after this PR:

    <html data-beasties-container><head>
      <style>.form-floating>~label{color:red}</style>
    </head><body>
      <div class="form-floating"><input><label>Foo</label></div>
    </body></html>

(no warning 👍🏻)