### PR TITLE
Add missing prop `allowRules` to `index.d.ts`

### DIFF
--- a/packages/beasties/src/index.d.ts
+++ b/packages/beasties/src/index.d.ts
@@ -59,6 +59,7 @@ export interface Options {
   noscriptFallback?: boolean
   inlineFonts?: boolean
   preloadFonts?: boolean
+  allowRules?: Array<string | RegExp>
   fonts?: boolean
   keyframes?: string
   compress?: boolean


### PR DESCRIPTION
While using `vite-plugin-beasties` on my Astro project, I noticed a typescript error when trying to pass `allowRules` in the options object. It seems that the prop was simply missing from the `Options` interface in `index.d.ts`.
![image](https://github.com/user-attachments/assets/38e5d487-4746-4f35-bb00-b0f51ea48531)

This PR simply adds the prop with the same signature as in `types.ts` to the declaration file.