### PR TITLE
fix(vite-plugin): properly remove css file from bundle when file is below inlineThreshold

### DIFF
--- a/packages/vite-plugin-beasties/src/index.ts
+++ b/packages/vite-plugin-beasties/src/index.ts
@@ -83,10 +83,10 @@ export function beasties(options: ViteBeastiesOptions = {}): Plugin {
       }
 
       const originalCheckInline = beastiesInstance.checkInlineThreshold.bind(beastiesInstance)
-      beastiesInstance.checkInlineThreshold = function checkInlineThreshold(style, before, sheetInverse) {
-        const isStyleInlined = originalCheckInline(style, before, sheetInverse)
+      beastiesInstance.checkInlineThreshold = function checkInlineThreshold(link, style, sheet) {
+        const isStyleInlined = originalCheckInline(link, style, sheet)
 
-        if (isStyleInlined || !sheetInverse.length) {
+        if (isStyleInlined || !sheet.length) {
           // @ts-expect-error internal property
           const name = style.$$name.replace(LEADING_SLASH_RE, '') as string
           if (name in bundle && bundle[name]!.type === 'asset') {

--- a/packages/vite-plugin-beasties/test/index.test.ts
+++ b/packages/vite-plugin-beasties/test/index.test.ts
@@ -100,6 +100,27 @@ describe('vite-plugin-beasties', () => {
     expect(otherHtml).not.toContain('<style>.test-content')
   })
 
+  it('inlines entire stylesheet when below inlineThreshold', async () => {
+    const { readOutput, output } = await runViteBuild({
+      options: {
+        inlineThreshold: 131072,
+      },
+    })
+    const html = readOutput('index.html')
+
+    // CSS should be fully inlined
+    expect(html).toContain('<style>')
+    const hasCssColor = html?.includes('color: blue') || html?.includes('color:#00f')
+    expect(hasCssColor).toBe(true)
+
+    // No external CSS file should remain in the bundle
+    const cssFile = output.find(file => file.fileName.endsWith('.css'))
+    expect(cssFile).toBeUndefined()
+
+    // No stylesheet link should remain in the HTML
+    expect(html).not.toContain('<link rel="stylesheet"')
+  })
+
   it('handles errors gracefully', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const errorSpy = vi.spyOn(Beasties.prototype, 'process').mockImplementation(() => {


### PR DESCRIPTION
Summary:
- checkInlineThreshold in the vite-plugin-beasties has a parameter mismatch causing an error when the inlineThreshold is set preventing css from inlining  

Solution:
- added a test showing the issue
- Updated the parameters for checkInlineThreshold to fix the mismatch

Resolves: https://github.com/danielroe/beasties/issues/298