### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-shell-emulator=true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beasties-root",
   "private": true,
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.1.2",
   "description": "Inline critical CSS and lazy-load the rest.",
   "author": "The Chromium Authors",
   "contributors": [

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,8 +6,7 @@ packages:
 overrides:
   beasties: 'workspace:*'
   vite-plugin-beasties: 'link:.'
-ignoredBuiltDependencies:
-  - esbuild
 
-onlyBuiltDependencies:
-  - simple-git-hooks
+allowBuilds:
+  esbuild: false
+  simple-git-hooks: true


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`