### PR TITLE
fix: preserve trailing semicolon on nested at-rule statements

### DIFF
--- a/packages/beasties/src/css.ts
+++ b/packages/beasties/src/css.ts
@@ -86,9 +86,18 @@ export function serializeStylesheet(ast: AnyNode, options: SerializeStylesheetOp
       return
     }
 
-    if (type === 'end' && result === '}' && node?.raws?.semicolon) {
+    if (
+      type === 'end'
+      && result === '}'
+      && node?.raws?.semicolon
+      && (node.type === 'rule' || node.type === 'atrule')
+    ) {
+      // Only drop the trailing `;` when it terminates a declaration body — for
+      // a nested at-rule statement (e.g. `@layer parent { @layer a, b; }`) the
+      // `;` is the statement terminator and stripping it produces invalid CSS.
+      const lastChild = node.nodes?.[node.nodes.length - 1]
       const lastItemIdx = cssParts.length - 2
-      if (lastItemIdx >= 0 && cssParts[lastItemIdx]) {
+      if (lastChild?.type === 'decl' && lastItemIdx >= 0 && cssParts[lastItemIdx]) {
         cssParts[lastItemIdx] = cssParts[lastItemIdx].slice(0, -1)
       }
     }

--- a/packages/beasties/test/serialize.test.ts
+++ b/packages/beasties/test/serialize.test.ts
@@ -19,4 +19,32 @@ describe('serialize CSS AST', () => {
       `"*{--un-backdrop-saturate: ;--un-backdrop-sepia: }:not(.test){height:inherit;width:inherit}"`,
     )
   })
+
+  it('should preserve trailing semicolon on a nested at-rule sub-layer declaration', () => {
+    // `@layer parent { @layer a, b; }` is a nested sub-layer declaration; the
+    // `;` terminates the inner statement and must survive minification.
+    const css = `
+      @layer parent { @layer a, b; }
+      @layer parent.a { .foo { color: red; } }
+    `
+    const ast = parseStylesheet(css)
+
+    expect(serializeStylesheet(ast, { compress: true })).toMatchInlineSnapshot(
+      `"@layer parent {@layer a, b;}@layer parent.a {.foo{color:red}}"`,
+    )
+  })
+
+  it('should still drop the redundant trailing semicolon inside an at-rule whose last child is a declaration', () => {
+    const css = `
+      @font-face {
+        font-family: 'X';
+        src: url('/x.woff2');
+      }
+    `
+    const ast = parseStylesheet(css)
+
+    expect(serializeStylesheet(ast, { compress: true })).toMatchInlineSnapshot(
+      `"@font-face {font-family:'X';src:url('/x.woff2')}"`,
+    )
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #322.

`serializeStylesheet`'s compress path stripped the trailing `;` of any container whose `raws.semicolon` was set, on the assumption it terminated a redundant declaration body. For a nested at-rule **statement** (e.g. `@layer parent { @layer a, b; }`) the `;` is the statement terminator — stripping it yields invalid CSS, and browsers then bail on subsequent rules in the parent at-rule.

The fix narrows the strip to cases where the parent's last child is a `decl`, leaving nested at-rule statements untouched.

### Before

```css
@layer parent {@layer a, b}@layer parent.a {.foo{color:red}}
```

### After

```css
@layer parent {@layer a, b;}@layer parent.a {.foo{color:red}}
```

## Verification

- New `serialize.test.ts` cases:
  - Preserves `;` on nested at-rule sub-layer declaration (the bug pattern)
  - Still strips the redundant `;` inside an at-rule whose last child is a declaration (e.g. `@font-face`) — locks in that the new guard doesn't over-restrict
- Ran the serializer end-to-end on real-world bundles before/after the patch:
  - **Bootstrap 5.3 minified (232 KB):** output byte-for-byte identical
  - **Vuetify 4.0 unminified (652 KB):** only 3 character differences in the whole bundle, all of them being the `;` previously stripped from `@layer vuetify-core { @layer reset, base; }`, `@layer vuetify-utilities { …; @layer theme-foreground; }`, and `@layer vuetify-final { @layer transitions, trumps; }`. Both outputs round-trip through `postcss.parse` without error.

## Test plan

- [x] `pnpm --filter beasties exec vitest run` — 56/56 pass (2 new)
- [x] `pnpm lint`
- [x] `pnpm test:types`