### PR TITLE
feat: processing multiple beasties containers

### DIFF
--- a/packages/beasties/README.md
+++ b/packages/beasties/README.md
@@ -244,6 +244,24 @@ You can estimate the contents of your viewport roughly and add a <div `data-beas
 </html>
 ```
 
+You can mark more than one element with `data-beasties-container`. CSS is then inlined if it matches inside _any_ of the containers, which is useful when the above-the-fold content is spread across multiple disconnected regions.
+
+```html
+<html>
+  <body>
+    <header data-beasties-container>
+      /* evaluated */
+    </header>
+    <main>
+      /* ignored */
+    </main>
+    <aside data-beasties-container>
+      /* evaluated */
+    </aside>
+  </body>
+</html>
+```
+
 _Note: This is an easy way to improve the performance of Beasties_
 
 ### Logger

--- a/packages/beasties/src/dom.ts
+++ b/packages/beasties/src/dom.ts
@@ -65,16 +65,18 @@ export function createDocument(html: string) {
   // Extend Element.prototype with DOM manipulation methods.
   extendElement(Element.prototype)
 
-  // Beasties container is the viewport to evaluate critical CSS
-  let beastiesContainer: Node | HTMLDocument = document.querySelector('[data-beasties-container]') as Node
+  // Beasties containers are the viewport to evaluate critical CSS.
+  let beastiesContainers: (Node | HTMLDocument)[] = document.querySelectorAll('[data-beasties-container]') as Node[]
 
-  if (!beastiesContainer) {
+  if (!beastiesContainers.length) {
     document.documentElement?.setAttribute('data-beasties-container', '')
-    beastiesContainer = document.documentElement || document
+    beastiesContainers = [document.documentElement || document]
   }
 
-  document.beastiesContainer = beastiesContainer
-  buildCache(beastiesContainer)
+  document.beastiesContainers = beastiesContainers
+  for (const container of beastiesContainers) {
+    buildCache(container)
+  }
 
   return document
 }
@@ -257,7 +259,11 @@ export interface HTMLDocument extends ParsedDocument {
   exists: (sel: string) => boolean
   querySelector: (sel: string) => Node
   querySelectorAll: (sel: string) => Node[]
+  /**
+   * @deprecated
+   */
   beastiesContainer: HTMLDocument | Node
+  beastiesContainers: (HTMLDocument | Node)[]
 }
 
 function extendDocument(document: ParsedDocument): asserts document is HTMLDocument {
@@ -334,6 +340,12 @@ function extendDocument(document: ParsedDocument): asserts document is HTMLDocum
           return this
         }
         return selectAll(sel, this)
+      },
+    },
+
+    beastiesContainer: {
+      get() {
+        return this.beastiesContainers?.[0]
       },
     },
   })

--- a/packages/beasties/src/index.ts
+++ b/packages/beasties/src/index.ts
@@ -489,7 +489,7 @@ export default class Beasties {
 
     const name = style.$$name ? style.$$name.replace(LEADING_SLASH_RE, '') : 'inline CSS'
     const options = this.options
-    const beastiesContainer = document.beastiesContainer!
+    const beastiesContainers = document.beastiesContainers!
     let keyframesMode = options.keyframes ?? 'critical'
     // we also accept a boolean value for options.keyframes
     if (keyframesMode === true)
@@ -608,7 +608,7 @@ export default class Beasties {
               return false
 
             try {
-              return beastiesContainer.exists(sel)
+              return beastiesContainers.some(container => container.exists(sel))
             }
             catch (e) {
               failedSelectors.push(`${sel} -> ${(e as Error).message || (e as Error).toString()}`)

--- a/packages/beasties/test/beasties.test.ts
+++ b/packages/beasties/test/beasties.test.ts
@@ -78,6 +78,96 @@ describe('beasties', () => {
     `)
   })
 
+  it('should inline critical CSS from multiple beasties containers', async () => {
+    const beasties = new Beasties()
+    const result = await beasties.process(trim`
+      <html>
+        <body>
+          <style>
+            .a { color: red }
+            .b { color: blue }
+            .c { color: green }
+          </style>
+          <div data-beasties-container>
+            <div class="a">A</div>
+          </div>
+          <div>
+            <div class="b">B</div>
+          </div>
+          <div data-beasties-container>
+            <div class="c">C</div>
+          </div>
+        </body>
+      </html>
+    `)
+    expect(result).toContain('.a{color:red}')
+    expect(result).toContain('.c{color:green}')
+    expect(result).not.toContain('.b{color:blue}')
+  })
+
+  it('should inline remote stylesheets from multiple beasties containers', async () => {
+    const beasties = new Beasties({
+      reduceInlineStyles: false,
+      path: '/',
+    })
+    const assets: Record<string, string> = {
+      '/style.css': trim`
+        .a { color: red }
+        .b { color: blue }
+        .c { color: green }
+      `,
+    }
+    beasties.readFile = filename => assets[filename.replace(/^\w:/, '').replace(/\\/g, '/')]!
+    const result = await beasties.process(trim`
+      <html>
+        <head>
+          <link rel="stylesheet" href="/style.css">
+        </head>
+        <body>
+          <div data-beasties-container>
+            <div class="a">A</div>
+          </div>
+          <div>
+            <div class="b">B</div>
+          </div>
+          <div data-beasties-container>
+            <div class="c">C</div>
+          </div>
+        </body>
+      </html>
+    `)
+    expect(result).toContain('<style>.a{color:red}.c{color:green}</style>')
+    expect(result).not.toContain('.b{color:blue}')
+    expect(result).toContain('<link rel="stylesheet" href="/style.css">')
+  })
+
+  it('should inline critical CSS from nested beasties containers', async () => {
+    const beasties = new Beasties()
+    const result = await beasties.process(trim`
+      <html>
+        <body>
+          <style>
+            .outer { color: red }
+            .inner { color: green }
+            .b { color: blue }
+          </style>
+          <div data-beasties-container>
+            <div class="outer">outer</div>
+            <div data-beasties-container>
+              <div class="inner">inner</div>
+            </div>
+          </div>
+          <div>
+            <div class="b">B</div>
+          </div>
+        </body>
+      </html>
+    `)
+    expect(result).toContain('.outer{color:red}')
+    expect(result).toContain('.inner{color:green}')
+    expect(result).not.toContain('.b{color:blue}')
+  })
+
   it('run on HTML file', async () => {
     const beasties = new Beasties({
       reduceInlineStyles: false,

--- a/packages/beasties/test/dom.test.ts
+++ b/packages/beasties/test/dom.test.ts
@@ -11,7 +11,7 @@ describe('dom', () => {
           </body>
         </html>
       `)
-      const container = doc.beastiesContainer
+      const container = doc.beastiesContainers[0]!
 
       /*
        ".parent .child" (descendant combinator) can't be resolved by the
@@ -29,7 +29,7 @@ describe('dom', () => {
           </body>
         </html>
       `)
-      const container = doc.beastiesContainer
+      const container = doc.beastiesContainers[0]!
 
       /*
         CSS comma means OR — both selectors are logically equivalent,
@@ -43,28 +43,32 @@ describe('dom', () => {
       const doc = createDocument(`
         <html><body><div class="hero">text</div></body></html>
       `)
-      expect(doc.beastiesContainer.exists('.hero')).toBe(true)
+      const container = doc.beastiesContainers[0]!
+      expect(container.exists('.hero')).toBe(true)
     })
 
     it('returns false for simple class selector that does not exist', () => {
       const doc = createDocument(`
         <html><body><div class="hero">text</div></body></html>
       `)
-      expect(doc.beastiesContainer.exists('.missing')).toBe(false)
+      const container = doc.beastiesContainers[0]!
+      expect(container.exists('.missing')).toBe(false)
     })
 
     it('returns true for simple id selector that exists', () => {
       const doc = createDocument(`
         <html><body><div id="main">text</div></body></html>
       `)
-      expect(doc.beastiesContainer.exists('#main')).toBe(true)
+      const container = doc.beastiesContainers[0]!
+      expect(container.exists('#main')).toBe(true)
     })
 
     it('returns false for simple id selector that does not exist', () => {
       const doc = createDocument(`
         <html><body><div id="main">text</div></body></html>
       `)
-      expect(doc.beastiesContainer.exists('#nope')).toBe(false)
+      const container = doc.beastiesContainers[0]!
+      expect(container.exists('#nope')).toBe(false)
     })
   })
 })


### PR DESCRIPTION
Beasties previously only looked at a single container. This PR allows marking multiple containers with `data-beasties-container`.

## Motivation

Sites usually build pages from nested components that live in different parts of the template tree:

<img width="1253" height="591" alt="image" src="https://github.com/user-attachments/assets/937ad888-b6b6-4629-a3a9-b4a3c05fd296" />

Here `AppHeader` sits in the layout and `Intro` is the first block on the page. Both are above the fold, so both need their critical CSS inlined, but they're in separate parts of the tree.

With a single container the option is to wrap both into one shared element. That means changing the existing markup and putting the header and the page content under a common wrapper, which goes against the normal layout/page split and can break styles or semantics.

One alternative is to keep the header in the critical CSS through `allowRules`, listing its selectors so they're never pruned. That works when you know the exact selectors, but it falls apart when the header is built with CSS Modules or CSS-in-JS. Since class names are generated during the build process, this approach does not offer a guaranteed solution.

With multiple containers you just mark `AppHeader` and `Intro` where they already are.