### PR TITLE
feat(beasties): add `data-beasties-skip` attribute to skip individual stylesheets

### DIFF
--- a/packages/beasties/README.md
+++ b/packages/beasties/README.md
@@ -246,6 +246,20 @@ You can estimate the contents of your viewport roughly and add a <div `data-beas
 
 _Note: This is an easy way to improve the performance of Beasties_
 
+### Skipping individual stylesheets
+
+If a stylesheet should not be processed by Beasties — for example a file that is injected or replaced at runtime (e.g. multi-tenant theming via Docker volume mounts) — add the `data-beasties-skip` boolean attribute to its `<link>` tag:
+
+```html
+<!-- processed normally -->
+<link rel="stylesheet" href="styles.css">
+
+<!-- skipped entirely — tag is left untouched in the final HTML -->
+<link rel="stylesheet" href="custom-theme.css" data-beasties-skip>
+```
+
+Beasties will not read, inline, prune, or mutate that tag regardless of the active preload strategy. This is useful when disabling `inlineCritical` globally would sacrifice Core Web Vitals optimizations for the rest of your stylesheets.
+
 ### Logger
 
 Custom logger interface:

--- a/packages/beasties/src/index.ts
+++ b/packages/beasties/src/index.ts
@@ -305,6 +305,10 @@ export default class Beasties {
    * Fetch CSS content for a linked stylesheet
    */
   private async fetchStylesheet(link: ChildNode, document: HTMLDocument): Promise<PreFetchedStylesheet | undefined> {
+    if (link.hasAttribute('data-beasties-skip')) {
+      return undefined
+    }
+
     const href = link.getAttribute('href')
 
     // skip filtered resources, or network resources if no filter is provided

--- a/packages/beasties/test/beasties.test.ts
+++ b/packages/beasties/test/beasties.test.ts
@@ -1086,4 +1086,79 @@ describe('beasties', () => {
 
     fs.rmSync(tmpDir, { recursive: true })
   })
+
+  describe('data-beasties-skip', () => {
+    const assets: Record<string, string> = {
+      '/styles.css': 'h1 { color: blue; }',
+      '/theme.css': 'body { background: red; }',
+    }
+
+    function makeBeasties(opts = {}) {
+      const b = new Beasties({ reduceInlineStyles: false, path: '/', ...opts })
+      b.readFile = filename => assets[filename.replace(/^\w:/, '').replace(/\\/g, '/')]!
+      return b
+    }
+
+    it('leaves the skipped link tag completely untouched', async () => {
+      const result = await makeBeasties().process(trim`
+        <html>
+          <head>
+            <link rel="stylesheet" href="/styles.css">
+            <link rel="stylesheet" href="/theme.css" data-beasties-skip>
+          </head>
+          <body><h1>Hello</h1></body>
+        </html>
+      `)
+      expect(result).toContain('<link rel="stylesheet" href="/theme.css" data-beasties-skip>')
+      expect(result).not.toMatch(/theme\.css[^>]*onload/)
+      expect(result).not.toMatch(/theme\.css[^>]*rel="preload"/)
+    })
+
+    it('still processes other links normally', async () => {
+      const result = await makeBeasties().process(trim`
+        <html>
+          <head>
+            <link rel="stylesheet" href="/styles.css">
+            <link rel="stylesheet" href="/theme.css" data-beasties-skip>
+          </head>
+          <body><h1>Hello</h1></body>
+        </html>
+      `)
+      expect(result).toContain('<style>')
+      expect(result).toContain('color:blue')
+      expect(result).not.toContain('background:red')
+    })
+
+    it('respects the skip attribute even when a preload strategy is active', async () => {
+      for (const preload of ['media', 'swap'] as const) {
+        const result = await makeBeasties({ preload }).process(trim`
+          <html>
+            <head>
+              <link rel="stylesheet" href="/styles.css">
+              <link rel="stylesheet" href="/theme.css" data-beasties-skip>
+            </head>
+            <body><h1>Hello</h1></body>
+          </html>
+        `)
+        expect(result).toContain('<link rel="stylesheet" href="/theme.css" data-beasties-skip>')
+        expect(result).not.toMatch(/theme\.css[^>]*onload/)
+        expect(result).not.toMatch(/theme\.css[^>]*rel="preload"/)
+      }
+    })
+
+    it('does not inject a noscript fallback for the skipped link', async () => {
+      const result = await makeBeasties({ preload: 'media' }).process(trim`
+        <html>
+          <head>
+            <link rel="stylesheet" href="/styles.css">
+            <link rel="stylesheet" href="/theme.css" data-beasties-skip>
+          </head>
+          <body><h1>Hello</h1></body>
+        </html>
+      `)
+      const noscriptMatches = result.match(/<noscript>/g) ?? []
+      expect(noscriptMatches.length).toBe(1)
+      expect(result).not.toMatch(/noscript[^>]*theme/)
+    })
+  })
 })


### PR DESCRIPTION
## Problem

There is currently no way to tell beasties to leave a specific `<link rel="stylesheet">`
tag untouched. Every stylesheet found in the document is subject to inlining, CSS pruning,
and preload strategy mutations — with no per-tag opt-out.

This is a problem whenever a stylesheet needs to remain a live, unmodified external
reference in the final HTML — because its contents will be provided or replaced after
the build. Common cases:

- **Runtime file replacement** — a placeholder file is present at build time but gets
  overwritten at deployment (e.g. via a Docker volume mount or a CI artifact swap).
- **Server-side generation** — the stylesheet is produced by the server at startup and
  does not exist yet when the build runs.
- **User-provided stylesheets** — the file path is known at build time but its contents
  are supplied externally (e.g. by an end user or a CMS).

In all three cases, beasties either throws (file not found) or mutates the `<link>` tag
to apply its preload strategy — changing `media`, injecting `onload` handlers, adding
`<noscript>` fallbacks. When the real stylesheet is later put in place, it ends up loaded
asynchronously with modified priority, causing FOUC or layout shifts.

The only existing workaround is disabling `inlineCritical` globally, which sacrifices
critical CSS inlining for every other stylesheet in the document.

## Solution

Add a `data-beasties-skip` boolean attribute. When present on a `<link rel="stylesheet">`,
beasties returns early from `fetchStylesheet()` before any file I/O, CSS parsing, or DOM
mutation occurs. The tag is copied to the output exactly as written, preserving the
synchronous external stylesheet reference for whatever replaces the file at runtime.

```html
<!-- processed normally -->
<link rel="stylesheet" href="styles.css">

<!-- left completely untouched in the final HTML -->
<link rel="stylesheet" href="custom-theme.css" data-beasties-skip>
```