### PR TITLE
feat(beasties): add compiler + zero-dependency critical css runtime

### DIFF
--- a/packages/beasties/package.json
+++ b/packages/beasties/package.json
@@ -38,7 +38,9 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs",
       "default": "./dist/index.mjs"
-    }
+    },
+    "./compiler": "./dist/compiler.mjs",
+    "./runtime": "./dist/runtime.mjs"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/beasties/src/compiler.ts
+++ b/packages/beasties/src/compiler.ts
@@ -1,0 +1,471 @@
+/**
+ * Build-time compiler for beasties.
+ *
+ * Compiles a CSS stylesheet into a JSON-serializable plan that the zero-dependency
+ * runtime (`beasties/runtime`) can evaluate against rendered HTML. All parsing
+ * (postcss, css-what), selector normalization, comment-marker handling and
+ * minification happens here, ahead of time.
+ */
+
+import type { Selector } from 'css-what'
+import type { AtRule, Container, Rule } from 'postcss'
+import { parse as parseSelectorAst } from 'css-what'
+import { parseStylesheet, serializeStylesheet } from './css'
+import { isAlwaysCriticalSelector, normalizeCssSelector } from './selectors'
+import { resolveCssUrl, rewriteCssUrls } from './urls'
+
+export type { CompactPlan } from './plan'
+export { encodePlan } from './plan-encode'
+
+// eslint-disable-next-line regexp/no-useless-assertions
+const BEASTIES_COMMENT_RE = /^(?<!! )beasties:(.*)/
+const FONT_FAMILY_RE = /\bfont(?:-family)?\b/i
+const WHITESPACE_RE = /\s+/
+// eslint-disable-next-line regexp/no-super-linear-backtracking,regexp/no-misleading-capturing-group
+const URL_RE = /url\s*\(\s*(['"]?)(.+?)\1\s*\)/
+
+const COMBINATOR_TOKENS: Record<string, Combinator> = {
+  descendant: ' ',
+  child: '>',
+  adjacent: '+',
+  sibling: '~',
+}
+
+const SUPPORTED_ATTR_ACTIONS = new Set(['exists', 'equals', 'element', 'start', 'end', 'any', 'hyphen'])
+
+/**
+ * Tokens which must all be present in the document for a selector to
+ * possibly match. This is a necessary (not sufficient) condition: selectors
+ * with combinators may be kept even though they don't match structurally.
+ *
+ * When `program` is present, the runtime evaluates it for an exact structural
+ * match during its scan pass, and the token fields serve only as a fallback
+ * for scans that did not evaluate programs.
+ */
+export interface TokenCondition {
+  classes?: string[]
+  ids?: string[]
+  tags?: string[]
+  attrs?: string[]
+  program?: StructuralProgram
+}
+
+export interface AttrTest {
+  name: string
+  action: 'exists' | 'equals' | 'element' | 'start' | 'end' | 'any' | 'hyphen'
+  value?: string
+  ignoreCase?: boolean
+}
+
+/** A single compound selector (no combinators); empty object matches any element */
+export interface CompoundTest {
+  tag?: string
+  ids?: string[]
+  classes?: string[]
+  attrs?: AttrTest[]
+}
+
+export type Combinator = ' ' | '>' | '+' | '~'
+
+/**
+ * A compiled selector for exact structural matching in a single streaming
+ * pass: `compounds` are separated by `combinators` (one fewer than compounds).
+ */
+export interface StructuralProgram {
+  compounds: CompoundTest[]
+  combinators: Combinator[]
+}
+
+/** `true` means the selector is always critical. */
+export type SelectorMatch = TokenCondition | true
+
+export interface CompiledRule {
+  /** Pre-serialized css text for atomic rules (at-rules, nested rules, markers) */
+  css?: string
+  /** Selector list, parallel to `match`, for rules whose selectors can be subset at runtime */
+  selectors?: string[]
+  /** Pre-serialized `{...}` body for `selectors` */
+  body?: string
+  /** Per-selector conditions (parallel to `selectors`), or rule-level conditions for atomic rules */
+  match?: SelectorMatch[]
+  /** Rule is always critical (markers, @import, etc.) */
+  always?: true
+  /** Chain of enclosing at-rule wrappers, each ending with `{` */
+  wrap?: string[]
+  /** Font-family values referenced by this rule's declarations */
+  fontsUsed?: string[]
+  /** Animation names referenced by this rule's declarations */
+  keyframesUsed?: string[]
+  /** This rule is an @font-face */
+  fontFace?: { family?: string, src?: string }
+  /** This rule is a @keyframes block with this name */
+  keyframes?: string
+}
+
+export interface CompiledSheet {
+  href?: string
+  rules: CompiledRule[]
+  /** Total size in bytes of the source stylesheet, for stats/thresholds */
+  size: number
+  warnings: string[]
+}
+
+export interface CompileOptions {
+  /** Identifier used to match this sheet against `<link>` hrefs at runtime */
+  href?: string
+  /**
+   * Always include rules matching these selectors or patterns in the critical CSS.
+   */
+  allowRules?: Array<string | RegExp>
+  /**
+   * Use PostCSS safe parser for fault-tolerant CSS parsing _(default: `true`)_
+   */
+  safeParser?: boolean
+  /**
+   * Compile selectors that need structural matching (combinators, compound
+   * co-occurrence, attribute values) into match programs the runtime evaluates
+   * exactly during its scan pass _(default: `true`)_.
+   *
+   * When disabled, such selectors fall back to token presence checks, which
+   * are cheaper but may over-inline rules whose parts all exist in the
+   * document without matching structurally.
+   */
+  exact?: boolean
+}
+
+interface MarkerState {
+  includeNext: boolean
+  excludeNext: boolean
+  includeAll: boolean
+  excludeAll: boolean
+}
+
+export function compileSheet(css: string, options: CompileOptions = {}): CompiledSheet {
+  const ast = parseStylesheet(css, { safeParser: options.safeParser !== false })
+  // once inlined, relative `url()` references resolve against the document
+  // rather than the stylesheet they came from, so they are rebased up front
+  const rebase = options.href
+    ? (text: string) => rewriteCssUrls(text, options.href!)
+    : (text: string) => text
+  const sheet: CompiledSheet = {
+    href: options.href,
+    rules: [],
+    size: css.length,
+    warnings: [],
+  }
+  const state: MarkerState = {
+    includeNext: false,
+    excludeNext: false,
+    includeAll: false,
+    excludeAll: false,
+  }
+
+  walk(ast, [], sheet, state, options, rebase)
+
+  return sheet
+}
+
+type Rebase = (text: string) => string
+
+function walk(container: Container, wrap: string[], sheet: CompiledSheet, state: MarkerState, options: CompileOptions, rebase: Rebase) {
+  for (const node of container.nodes ?? []) {
+    if (node.type === 'comment') {
+      const match = node.text.match(BEASTIES_COMMENT_RE)
+      const command = match && match[1]
+      if (command) {
+        switch (command) {
+          case 'include':
+            state.includeNext = true
+            break
+          case 'exclude':
+            state.excludeNext = true
+            break
+          case 'include start':
+            state.includeAll = true
+            break
+          case 'include end':
+            state.includeAll = false
+            break
+          case 'exclude start':
+            state.excludeAll = true
+            break
+          case 'exclude end':
+            state.excludeAll = false
+            break
+        }
+      }
+      continue
+    }
+
+    if (node.type === 'rule') {
+      compileRule(node, wrap, sheet, state, options, rebase)
+      continue
+    }
+
+    if (node.type === 'atrule') {
+      compileAtRule(node, wrap, sheet, state, options, rebase)
+    }
+  }
+}
+
+function compileRule(rule: Rule, wrap: string[], sheet: CompiledSheet, state: MarkerState, options: CompileOptions, rebase: Rebase) {
+  if (state.includeNext) {
+    state.includeNext = false
+    // marker-included rules don't contribute font/keyframe usage
+    sheet.rules.push(withWrap({ css: rebase(serializeStylesheet(rule, { compress: true })), always: true }, wrap))
+    return
+  }
+  if (state.excludeNext) {
+    state.excludeNext = false
+    return
+  }
+  if (state.includeAll) {
+    sheet.rules.push(withWrap({ css: rebase(serializeStylesheet(rule, { compress: true })), always: true }, wrap))
+    return
+  }
+  if (state.excludeAll) {
+    return
+  }
+
+  const selectors: string[] = []
+  const match: SelectorMatch[] = []
+
+  for (const sel of rule.selectors) {
+    const condition = compileSelector(sel, sheet, options)
+    if (condition === false) {
+      continue
+    }
+    selectors.push(sel)
+    match.push(condition)
+  }
+
+  if (selectors.length === 0) {
+    return
+  }
+
+  const compiled: CompiledRule = { selectors, match }
+
+  const hasNested = rule.nodes?.some(n => n.type === 'rule' || n.type === 'atrule')
+  if (hasNested) {
+    // CSS nesting: treat the rule as atomic, matched on its top-level selectors
+    compiled.css = rebase(serializeStylesheet(rule, { compress: true }))
+    delete compiled.selectors
+    compiled.match = match
+  }
+  else {
+    const original = rule.selector
+    rule.selector = '\0'
+    const text = serializeStylesheet(rule, { compress: true })
+    rule.selector = original
+    compiled.body = rebase(text.slice(text.indexOf('\0') + 1))
+  }
+
+  collectDependencies(rule, compiled)
+
+  sheet.rules.push(withWrap(compiled, wrap))
+}
+
+function compileAtRule(rule: AtRule, wrap: string[], sheet: CompiledSheet, state: MarkerState, options: CompileOptions, rebase: Rebase) {
+  const name = rule.name
+
+  if (name === 'keyframes' || name === '-webkit-keyframes') {
+    sheet.rules.push(withWrap({
+      css: rebase(serializeStylesheet(rule, { compress: true })),
+      keyframes: rule.params,
+    }, wrap))
+    return
+  }
+
+  if (name === 'font-face') {
+    let family: string | undefined
+    let src: string | undefined
+    for (const decl of rule.nodes ?? []) {
+      if (!('prop' in decl))
+        continue
+      if (decl.prop === 'src') {
+        src = (decl.value.match(URL_RE) || [])[2]
+      }
+      else if (decl.prop === 'font-family') {
+        family = decl.value
+      }
+    }
+    sheet.rules.push(withWrap({
+      css: rebase(serializeStylesheet(rule, { compress: true })),
+      fontFace: { family, src: src && options.href ? resolveCssUrl(src.trim(), options.href) : src },
+    }, wrap))
+    return
+  }
+
+  const hasNestedRules = rule.nodes?.some(n => n.type === 'rule' || n.type === 'atrule')
+
+  if (hasNestedRules) {
+    const open = `@${name}${rule.raws.afterName ?? ' '}${rule.params}${rule.raws.between ?? ''}{`
+    const childWrap = [...wrap, open]
+    if (name === 'layer') {
+      // @layer blocks establish cascade order, so they're preserved even when
+      // all their rules are pruned; this marker forces the wrapper to be emitted
+      sheet.rules.push({ css: '', always: true, wrap: childWrap })
+    }
+    walk(rule, childWrap, sheet, state, options, rebase)
+    return
+  }
+
+  // statement at-rules (@import, @charset, @namespace, `@layer a, b;`, ...)
+  // need an explicit terminator as they're serialized standalone
+  let css = rebase(serializeStylesheet(rule, { compress: true }))
+  if (!css.endsWith(';')) {
+    css += ';'
+  }
+  sheet.rules.push(withWrap({ css, always: true }, wrap))
+}
+
+function compileSelector(sel: string, sheet: CompiledSheet, options: CompileOptions): SelectorMatch | false {
+  const isAllowedRule = options.allowRules?.some((exp) => {
+    if (exp instanceof RegExp) {
+      return exp.test(sel)
+    }
+    return exp === sel
+  })
+  if (isAllowedRule) {
+    return true
+  }
+
+  if (isAlwaysCriticalSelector(sel)) {
+    return true
+  }
+
+  const normalized = normalizeCssSelector(sel)
+  if (!normalized) {
+    return false
+  }
+
+  let parsed
+  try {
+    parsed = parseSelectorAst(normalized)
+  }
+  catch (e) {
+    sheet.warnings.push(`${normalized} -> ${(e as Error).message || String(e)}`)
+    return false
+  }
+
+  const condition: TokenCondition = {}
+  let simpleTokens = 0
+  let compounds = 1
+  let hasValuedAttr = false
+  for (const token of parsed.flat()) {
+    if (token.type === 'attribute') {
+      simpleTokens++
+      if (token.name === 'class' && (token.action === 'element' || token.action === 'equals')) {
+        for (const cls of token.value.split(WHITESPACE_RE)) {
+          if (cls)
+            (condition.classes ??= []).push(cls)
+        }
+      }
+      else if (token.name === 'id' && token.action === 'equals') {
+        (condition.ids ??= []).push(token.value)
+      }
+      else {
+        if (token.action !== 'exists') {
+          hasValuedAttr = true
+        }
+        (condition.attrs ??= []).push(token.name.toLowerCase())
+      }
+    }
+    else if (token.type === 'tag') {
+      simpleTokens++;
+      (condition.tags ??= []).push(token.name.toLowerCase())
+    }
+    else if (token.type in COMBINATOR_TOKENS) {
+      compounds++
+    }
+  }
+
+  if (!condition.classes && !condition.ids && !condition.tags && !condition.attrs) {
+    return true
+  }
+
+  // a single simple token is exactly decided by document-level presence
+  if (compounds === 1 && simpleTokens === 1 && !hasValuedAttr) {
+    return condition
+  }
+
+  if (options.exact !== false && parsed.length === 1) {
+    const program = buildProgram(parsed[0]!)
+    if (program) {
+      condition.program = program
+    }
+  }
+
+  return condition
+}
+
+function buildProgram(tokens: Selector[]): StructuralProgram | null {
+  const compounds: CompoundTest[] = []
+  const combinators: Combinator[] = []
+  let current: CompoundTest = {}
+
+  for (const token of tokens) {
+    if (token.type === 'universal') {
+      continue
+    }
+    if (token.type in COMBINATOR_TOKENS) {
+      compounds.push(current)
+      combinators.push(COMBINATOR_TOKENS[token.type]!)
+      current = {}
+      continue
+    }
+    if (token.type === 'tag') {
+      current.tag = token.name.toLowerCase()
+      continue
+    }
+    if (token.type === 'attribute') {
+      if (token.name === 'class' && token.action === 'element') {
+        (current.classes ??= []).push(token.value)
+        continue
+      }
+      if (token.name === 'id' && token.action === 'equals') {
+        (current.ids ??= []).push(token.value)
+        continue
+      }
+      if (!SUPPORTED_ATTR_ACTIONS.has(token.action)) {
+        return null
+      }
+      (current.attrs ??= []).push({
+        name: token.name.toLowerCase(),
+        action: token.action as AttrTest['action'],
+        value: token.value,
+        ignoreCase: token.ignoreCase === true || undefined,
+      })
+      continue
+    }
+    return null
+  }
+
+  compounds.push(current)
+  return { compounds, combinators }
+}
+
+function collectDependencies(rule: Rule, compiled: CompiledRule) {
+  for (const decl of rule.nodes ?? []) {
+    if (!('prop' in decl)) {
+      continue
+    }
+    if (FONT_FAMILY_RE.test(decl.prop)) {
+      (compiled.fontsUsed ??= []).push(decl.value)
+    }
+    if (decl.prop === 'animation' || decl.prop === 'animation-name') {
+      for (const name of decl.value.split(WHITESPACE_RE)) {
+        const trimmed = name.trim()
+        if (trimmed)
+          (compiled.keyframesUsed ??= []).push(trimmed)
+      }
+    }
+  }
+}
+
+function withWrap(rule: CompiledRule, wrap: string[]): CompiledRule {
+  if (wrap.length > 0) {
+    rule.wrap = wrap
+  }
+  return rule
+}

--- a/packages/beasties/src/index.ts
+++ b/packages/beasties/src/index.ts
@@ -24,16 +24,12 @@ import path from 'node:path'
 
 import { applyMarkedSelectors, markOnly, parseStylesheet, serializeStylesheet, validateMediaQuery, walkStyleRules, walkStyleRulesWithReverseMirror } from './css'
 import { createDocument, serializeDocument } from './dom'
+import { isAlwaysCriticalSelector, normalizeCssSelector } from './selectors'
+import { REMOTE_URL_RE, resolveCssUrl, rewriteCssUrls } from './urls'
 import { createLogger, isSubpath } from './util'
 
-const removePseudoClassesAndElementsPattern = /(?<!\\)::?[a-z-]+(?:\(.+\))?/gi
-const implicitUniversalPattern = /([>+~])\s*(?!\1)([>+~])/g
-const emptyCombinatorPattern = /([>+~])\s*(?=\1|$)/g
-const removeTrailingCommasPattern = /\(\s*,|,\s*\)/g
 const LEADING_SLASH_OR_QUERY_RE = /^\/(?!\/)|[?#].*$/g
 const PUBLIC_PATH_RE = /(^\/(?!\/)|\/$)/g
-const REMOTE_URL_RE = /^https?:\/\//
-const BEFORE_AFTER_PSEUDO_RE = /^::?(?:before|after)$/
 const FONT_FAMILY_RE = /\bfont(?:-family)?\b/i
 // eslint-disable-next-line regexp/no-useless-assertions
 const BEASTIES_COMMENT_RE = /^(?<!! )beasties:(.*)/
@@ -41,10 +37,6 @@ const LEADING_SLASH_RE = /^\//
 const WHITESPACE_RE = /\s+/
 // eslint-disable-next-line regexp/no-super-linear-backtracking,regexp/no-misleading-capturing-group
 const URL_RE = /url\s*\(\s*(['"]?)(.+?)\1\s*\)/
-// unquoted urls cannot contain unescaped parentheses, and excluding them keeps
-// backtracking linear on input like `url((((...`
-const URL_RE_G = /url\((?:'([^']*)'|"([^"]*)"|([^()]*))\)/gi
-const ABSOLUTE_URL_RE = /^(?:[a-z][\w+.-]*:|\/\/|\/|#)/i
 
 interface PreFetchedStylesheet {
   link: ChildNode
@@ -605,12 +597,7 @@ export default class Beasties {
 
             // Strip pseudo-elements and pseudo-classes, since we only care that their associated elements exist.
             // This means any selector for a pseudo-element or having a pseudo-class will be inlined if the rest of the selector matches.
-            if (
-              sel === ':root'
-              || sel === 'html'
-              || sel === 'body'
-              || (sel[0] === ':' && BEFORE_AFTER_PSEUDO_RE.test(sel))
-            ) {
+            if (isAlwaysCriticalSelector(sel)) {
               return true
             }
 
@@ -788,56 +775,12 @@ export default class Beasties {
       return normalizedSelector
     }
 
-    normalizedSelector = sel
-      .replace(removePseudoClassesAndElementsPattern, '')
-      .replace(removeTrailingCommasPattern, match => (match.includes('(') ? '(' : ')'))
-      .replace(implicitUniversalPattern, '$1 * $2')
-      .replace(emptyCombinatorPattern, '$1 *')
-      .trim()
+    normalizedSelector = normalizeCssSelector(sel)
 
     this.#selectorCache.set(sel, normalizedSelector)
 
     return normalizedSelector
   }
-}
-
-/**
- * Resolve a `url()` value that is relative to `baseHref` (the location of the
- * stylesheet it was declared in) so that it can be used from the document instead.
- */
-function resolveCssUrl(url: string, baseHref: string): string {
-  if (!url || ABSOLUTE_URL_RE.test(url)) {
-    return url
-  }
-
-  const base = baseHref.split('?')[0]!.split('#')[0]!
-
-  if (REMOTE_URL_RE.test(base) || base.startsWith('//')) {
-    try {
-      const resolved = new URL(url, base.startsWith('//') ? `https:${base}` : base)
-      return base.startsWith('//') ? resolved.href.replace(REMOTE_URL_RE, '//') : resolved.href
-    }
-    catch {
-      return url
-    }
-  }
-
-  const dir = path.posix.dirname(base)
-  // the stylesheet sits alongside the document, so relative urls already resolve correctly
-  if (dir === '.' || dir === '') {
-    return url
-  }
-
-  return path.posix.join(dir, url)
-}
-
-function rewriteCssUrls(css: string, baseHref: string): string {
-  return css.replace(URL_RE_G, (match, singleQuoted?: string, doubleQuoted?: string, bare?: string) => {
-    const quote = singleQuoted !== undefined ? '\'' : doubleQuoted !== undefined ? '"' : ''
-    const url = singleQuoted ?? doubleQuoted ?? bare?.trim() ?? ''
-    const resolved = resolveCssUrl(url, baseHref)
-    return resolved === url ? match : `url(${quote}${resolved}${quote})`
-  })
 }
 
 function formatSize(size: number) {

--- a/packages/beasties/src/plan-decode.ts
+++ b/packages/beasties/src/plan-decode.ts
@@ -1,0 +1,168 @@
+import type { AttrTest, CompiledRule, CompiledSheet, CompoundTest, SelectorMatch, StructuralProgram, TokenCondition } from './compiler'
+import type { CompactAttr, CompactCompound, CompactMatch, CompactPlan, CompactProgram, CompactRule, CompactTokens, PooledString } from './plan'
+
+import {
+  ATTR_ACTIONS,
+  F_ALWAYS,
+  F_CSS,
+  F_FONT_FACE,
+  F_FONTS_USED,
+  F_KEYFRAMES,
+  F_KEYFRAMES_USED,
+  F_MATCH,
+  F_SELECTORS,
+  F_WRAP,
+  M_CLASS,
+  M_ID,
+  M_TAG,
+  M_TRUE,
+} from './plan'
+
+export function decodePlan(plan: CompactPlan): CompiledSheet {
+  const [, href, size, pool, wraps, rules] = plan
+  const deref = (value: PooledString): string => (typeof value === 'number' ? pool[value]! : value)
+  const derefAll = (values: PooledString[]): string[] => values.map(deref)
+  const wrapChains = wraps.map(derefAll)
+
+  return {
+    href: href === 0 ? undefined : href,
+    size,
+    warnings: [],
+    rules: rules.map(rule => decodeRule(rule, deref, derefAll, wrapChains)),
+  }
+}
+
+function decodeRule(
+  compact: CompactRule,
+  deref: (value: PooledString) => string,
+  derefAll: (values: PooledString[]) => string[],
+  wrapChains: string[][],
+): CompiledRule {
+  const flags = compact[0] as number
+  let cursor = 1
+  const next = <T>(): T => compact[cursor++] as T
+  const rule: CompiledRule = {}
+
+  if (flags & F_SELECTORS) {
+    const selectors = next<PooledString | PooledString[]>()
+    rule.selectors = Array.isArray(selectors) ? derefAll(selectors) : [deref(selectors)]
+    rule.body = deref(next<PooledString>())
+  }
+  if (flags & F_CSS) {
+    rule.css = deref(next<PooledString>())
+  }
+  if (flags & F_MATCH) {
+    rule.match = next<CompactMatch[]>().map((condition, index) => decodeMatch(condition, rule.selectors?.[index], deref, derefAll))
+  }
+  if (flags & F_ALWAYS) {
+    rule.always = true
+  }
+  if (flags & F_WRAP) {
+    rule.wrap = wrapChains[next<number>()]!
+  }
+  if (flags & F_FONTS_USED) {
+    rule.fontsUsed = derefAll(next<PooledString[]>())
+  }
+  if (flags & F_KEYFRAMES_USED) {
+    rule.keyframesUsed = derefAll(next<PooledString[]>())
+  }
+  if (flags & F_FONT_FACE) {
+    const [family, src] = next<[PooledString | 0, PooledString | 0]>()
+    rule.fontFace = {
+      family: family === 0 ? undefined : deref(family),
+      src: src === 0 ? undefined : deref(src),
+    }
+  }
+  if (flags & F_KEYFRAMES) {
+    rule.keyframes = deref(next<PooledString>())
+  }
+
+  return rule
+}
+
+function decodeMatch(
+  compact: CompactMatch,
+  selector: string | undefined,
+  deref: (value: PooledString) => string,
+  derefAll: (values: PooledString[]) => string[],
+): SelectorMatch {
+  if (compact === M_TRUE) {
+    return true
+  }
+  if (compact === M_CLASS) {
+    return { classes: [selector!.slice(1)] }
+  }
+  if (compact === M_ID) {
+    return { ids: [selector!.slice(1)] }
+  }
+  if (compact === M_TAG) {
+    return { tags: [selector!.toLowerCase()] }
+  }
+  // only a program's first slot is a string (its combinator sequence)
+  if (typeof compact[0] === 'string') {
+    return { program: decodeProgram(compact as CompactProgram, deref, derefAll) }
+  }
+
+  const [classes, ids, tags, attrs] = compact as CompactTokens
+  const condition: TokenCondition = {}
+  if (classes !== 0) {
+    condition.classes = derefAll(classes)
+  }
+  if (ids !== 0) {
+    condition.ids = derefAll(ids)
+  }
+  if (tags !== 0) {
+    condition.tags = derefAll(tags)
+  }
+  if (attrs !== 0) {
+    condition.attrs = derefAll(attrs)
+  }
+  return condition
+}
+
+function decodeProgram(
+  compact: CompactProgram,
+  deref: (value: PooledString) => string,
+  derefAll: (values: PooledString[]) => string[],
+): StructuralProgram {
+  const [combinators, compounds] = compact
+  return {
+    combinators: [...combinators] as StructuralProgram['combinators'],
+    compounds: compounds.map(compound => decodeCompound(compound, deref, derefAll)),
+  }
+}
+
+function decodeCompound(
+  compact: CompactCompound,
+  deref: (value: PooledString) => string,
+  derefAll: (values: PooledString[]) => string[],
+): CompoundTest {
+  if (!Array.isArray(compact)) {
+    return { classes: [deref(compact)] }
+  }
+
+  const [tag, classes, ids, attrs] = compact
+  const compound: CompoundTest = {}
+  if (tag !== 0) {
+    compound.tag = deref(tag)
+  }
+  if (classes !== 0) {
+    compound.classes = derefAll(classes)
+  }
+  if (ids !== 0) {
+    compound.ids = derefAll(ids)
+  }
+  if (attrs !== 0) {
+    compound.attrs = attrs.map(([name, action, value, ignoreCase]: CompactAttr): AttrTest => {
+      const test: AttrTest = { name: deref(name), action: ATTR_ACTIONS[action]! }
+      if (value !== 0) {
+        test.value = deref(value)
+      }
+      if (ignoreCase) {
+        test.ignoreCase = true
+      }
+      return test
+    })
+  }
+  return compound
+}

--- a/packages/beasties/src/plan-encode.ts
+++ b/packages/beasties/src/plan-encode.ts
@@ -1,0 +1,279 @@
+import type { CompiledRule, CompiledSheet, SelectorMatch, StructuralProgram, TokenCondition } from './compiler'
+import type { CompactAttr, CompactCompound, CompactMatch, CompactPlan, CompactProgram, CompactRule, PooledString } from './plan'
+
+import {
+  ATTR_ACTIONS,
+  F_ALWAYS,
+  F_CSS,
+  F_FONT_FACE,
+  F_FONTS_USED,
+  F_KEYFRAMES,
+  F_KEYFRAMES_USED,
+  F_MATCH,
+  F_SELECTORS,
+  F_WRAP,
+  M_CLASS,
+  M_ID,
+  M_TAG,
+  M_TRUE,
+} from './plan'
+
+/**
+ * Collects string frequencies so only strings used more than once are pooled;
+ * pooling a unique string would cost more than inlining it.
+ */
+class StringPool {
+  #counts = new Map<string, number>()
+  #indices = new Map<string, number>()
+  strings: string[] = []
+
+  count(value: string | undefined): void {
+    if (value === undefined) {
+      return
+    }
+    this.#counts.set(value, (this.#counts.get(value) ?? 0) + 1)
+  }
+
+  finalize(): void {
+    for (const [value, count] of this.#counts) {
+      if (count > 1) {
+        this.#indices.set(value, this.strings.length)
+        this.strings.push(value)
+      }
+    }
+  }
+
+  ref(value: string): PooledString {
+    return this.#indices.get(value) ?? value
+  }
+
+  refs(values: string[]): PooledString[] {
+    return values.map(value => this.ref(value))
+  }
+}
+
+export function encodePlan(sheet: CompiledSheet): CompactPlan {
+  const pool = new StringPool()
+  const wrapKeys = new Map<string, number>()
+  const wraps: string[][] = []
+
+  for (const rule of sheet.rules) {
+    countRule(rule, pool)
+    if (rule.wrap) {
+      const key = rule.wrap.join('\0')
+      if (!wrapKeys.has(key)) {
+        wrapKeys.set(key, wraps.length)
+        wraps.push(rule.wrap)
+      }
+    }
+  }
+  for (const wrap of wraps) {
+    for (const part of wrap) {
+      pool.count(part)
+    }
+  }
+  pool.finalize()
+
+  return [
+    1,
+    sheet.href ?? 0,
+    sheet.size,
+    pool.strings,
+    wraps.map(wrap => pool.refs(wrap)),
+    sheet.rules.map(rule => encodeRule(rule, pool, wrapKeys)),
+  ]
+}
+
+function countRule(rule: CompiledRule, pool: StringPool) {
+  if (rule.selectors) {
+    for (const selector of rule.selectors) {
+      pool.count(selector)
+    }
+    pool.count(rule.body)
+  }
+  pool.count(rule.css)
+  if (rule.match) {
+    for (const condition of rule.match) {
+      countCondition(condition, pool)
+    }
+  }
+  for (const value of rule.fontsUsed ?? []) {
+    pool.count(value)
+  }
+  for (const value of rule.keyframesUsed ?? []) {
+    pool.count(value)
+  }
+  pool.count(rule.keyframes)
+  pool.count(rule.fontFace?.family)
+  pool.count(rule.fontFace?.src)
+}
+
+function countCondition(condition: SelectorMatch, pool: StringPool) {
+  if (condition === true) {
+    return
+  }
+  if (condition.program) {
+    // token fields are dropped by the encoding when a program is present
+    for (const compound of condition.program.compounds) {
+      pool.count(compound.tag)
+      for (const value of compound.classes ?? []) {
+        pool.count(value)
+      }
+      for (const value of compound.ids ?? []) {
+        pool.count(value)
+      }
+      for (const attr of compound.attrs ?? []) {
+        pool.count(attr.name)
+        pool.count(attr.value)
+      }
+    }
+    return
+  }
+  for (const list of [condition.classes, condition.ids, condition.tags, condition.attrs]) {
+    for (const value of list ?? []) {
+      pool.count(value)
+    }
+  }
+}
+
+function encodeRule(rule: CompiledRule, pool: StringPool, wrapKeys: Map<string, number>): CompactRule {
+  let flags = 0
+  const fields: unknown[] = []
+
+  if (rule.selectors && rule.body !== undefined) {
+    flags |= F_SELECTORS
+    // the common single-selector case skips the array wrapper
+    fields.push(
+      rule.selectors.length === 1 ? pool.ref(rule.selectors[0]!) : pool.refs(rule.selectors),
+      pool.ref(rule.body),
+    )
+  }
+  if (rule.css !== undefined) {
+    flags |= F_CSS
+    fields.push(pool.ref(rule.css))
+  }
+  if (rule.match) {
+    flags |= F_MATCH
+    fields.push(rule.match.map((condition, index) => encodeMatch(condition, rule.selectors?.[index], pool)))
+  }
+  if (rule.always) {
+    flags |= F_ALWAYS
+  }
+  if (rule.wrap) {
+    flags |= F_WRAP
+    fields.push(wrapKeys.get(rule.wrap.join('\0'))!)
+  }
+  if (rule.fontsUsed) {
+    flags |= F_FONTS_USED
+    fields.push(pool.refs(rule.fontsUsed))
+  }
+  if (rule.keyframesUsed) {
+    flags |= F_KEYFRAMES_USED
+    fields.push(pool.refs(rule.keyframesUsed))
+  }
+  if (rule.fontFace) {
+    flags |= F_FONT_FACE
+    fields.push([
+      rule.fontFace.family === undefined ? 0 : pool.ref(rule.fontFace.family),
+      rule.fontFace.src === undefined ? 0 : pool.ref(rule.fontFace.src),
+    ])
+  }
+  if (rule.keyframes !== undefined) {
+    flags |= F_KEYFRAMES
+    fields.push(pool.ref(rule.keyframes))
+  }
+
+  return [flags, ...fields]
+}
+
+/**
+ * Most conditions restate their selector (`.foo` -> `{ classes: ['foo'] }`).
+ * Those are stored as a marker and rederived at decode time, but only when the
+ * derivation round-trips exactly: escaped selectors (`.md\:flex`) parse to a
+ * different value than their source text.
+ *
+ * When a structural program is present it decides the match on its own, so the
+ * token fields are dropped. A scan that doesn't evaluate programs then treats
+ * such a selector as critical rather than checking tokens, which over-inlines
+ * but never drops a rule.
+ */
+function encodeMatch(condition: SelectorMatch, selector: string | undefined, pool: StringPool): CompactMatch {
+  if (condition === true) {
+    return M_TRUE
+  }
+  if (condition.program) {
+    return encodeProgram(condition.program, pool)
+  }
+  if (selector !== undefined) {
+    for (const marker of [M_CLASS, M_ID, M_TAG] as const) {
+      const derived = deriveCondition(marker, selector)
+      if (derived && sameCondition(derived, condition)) {
+        return marker
+      }
+    }
+  }
+
+  return [
+    condition.classes ? pool.refs(condition.classes) : 0,
+    condition.ids ? pool.refs(condition.ids) : 0,
+    condition.tags ? pool.refs(condition.tags) : 0,
+    condition.attrs ? pool.refs(condition.attrs) : 0,
+  ]
+}
+
+function deriveCondition(marker: typeof M_CLASS | typeof M_ID | typeof M_TAG, selector: string): TokenCondition | undefined {
+  if (marker === M_TAG) {
+    return { tags: [selector.toLowerCase()] }
+  }
+  const expectedPrefix = marker === M_CLASS ? '.' : '#'
+  if (selector[0] !== expectedPrefix) {
+    return undefined
+  }
+  const value = selector.slice(1)
+  return marker === M_CLASS ? { classes: [value] } : { ids: [value] }
+}
+
+function sameCondition(a: TokenCondition, b: TokenCondition): boolean {
+  for (const key of ['classes', 'ids', 'tags', 'attrs'] as const) {
+    const left = a[key]
+    const right = b[key]
+    if (left === undefined || right === undefined) {
+      if (left !== right) {
+        return false
+      }
+      continue
+    }
+    if (left.length !== right.length || left.some((value, index) => value !== right[index])) {
+      return false
+    }
+  }
+  return true
+}
+
+function encodeProgram(program: StructuralProgram, pool: StringPool): CompactProgram {
+  return [
+    program.combinators.join(''),
+    program.compounds.map((compound): CompactCompound => {
+      const onlyClass = compound.classes?.length === 1
+        && compound.tag === undefined
+        && !compound.ids
+        && !compound.attrs
+      if (onlyClass) {
+        return pool.ref(compound.classes![0]!)
+      }
+      return [
+        compound.tag === undefined ? 0 : pool.ref(compound.tag),
+        compound.classes ? pool.refs(compound.classes) : 0,
+        compound.ids ? pool.refs(compound.ids) : 0,
+        compound.attrs
+          ? compound.attrs.map((attr): CompactAttr => [
+              pool.ref(attr.name),
+              ATTR_ACTIONS.indexOf(attr.action),
+              attr.value === undefined ? 0 : pool.ref(attr.value),
+              attr.ignoreCase ? 1 : 0,
+            ])
+          : 0,
+      ]
+    }),
+  ]
+}

--- a/packages/beasties/src/plan.ts
+++ b/packages/beasties/src/plan.ts
@@ -1,0 +1,77 @@
+/**
+ * Compact wire format for compiled plans.
+ *
+ * `CompiledSheet` is convenient to produce and consume but verbose to embed in
+ * a server bundle: object keys repeat per rule, and most `match` conditions
+ * merely restate their selector. `encodePlan` rewrites a sheet as positional
+ * arrays with a shared string pool, and `decodePlan` restores it, so the
+ * runtime's hot path works on exactly the same shapes as before.
+ *
+ * Build-time diagnostics (`warnings`) are dropped by the encoding.
+ */
+
+import type { AttrTest } from './compiler'
+
+/** A string, or an index into the plan's string pool */
+export type PooledString = string | number
+
+export type CompactPlan = [
+  version: 1,
+  href: string | 0,
+  size: number,
+  pool: string[],
+  wraps: PooledString[][],
+  rules: CompactRule[],
+]
+
+/** `[flags, ...present fields in flag order]` */
+export type CompactRule = unknown[]
+
+/**
+ * A selector's match condition. Small integers are markers for conditions
+ * rederivable from the selector text; arrays are discriminated by their first
+ * slot, which is a string only for programs (the combinator sequence).
+ */
+export type CompactMatch = 0 | 1 | 2 | 3 | CompactProgram | CompactTokens
+
+export type CompactTokens = [
+  classes: PooledString[] | 0,
+  ids: PooledString[] | 0,
+  tags: PooledString[] | 0,
+  attrs: PooledString[] | 0,
+]
+
+export type CompactProgram = [combinators: string, compounds: CompactCompound[]]
+
+/** A bare value is a compound of one class; anything else uses the array form */
+export type CompactCompound = PooledString | [
+  tag: PooledString | 0,
+  classes: PooledString[] | 0,
+  ids: PooledString[] | 0,
+  attrs: CompactAttr[] | 0,
+]
+
+export type CompactAttr = [name: PooledString, action: number, value: PooledString | 0, ignoreCase: 0 | 1]
+
+export const F_SELECTORS = 1
+export const F_CSS = 2
+export const F_MATCH = 4
+export const F_ALWAYS = 8
+export const F_WRAP = 16
+export const F_FONTS_USED = 32
+export const F_KEYFRAMES_USED = 64
+export const F_FONT_FACE = 128
+export const F_KEYFRAMES = 256
+
+/** condition is exactly `{ classes: [selector.slice(1)] }`, etc. */
+export const M_TRUE = 0
+export const M_CLASS = 1
+export const M_ID = 2
+export const M_TAG = 3
+
+export const ATTR_ACTIONS: AttrTest['action'][] = ['exists', 'equals', 'element', 'start', 'end', 'any', 'hyphen']
+
+/** Whether a value is a compact plan rather than a `CompiledSheet` */
+export function isCompactPlan(plan: unknown): plan is CompactPlan {
+  return Array.isArray(plan) && plan[0] === 1
+}

--- a/packages/beasties/src/runtime.ts
+++ b/packages/beasties/src/runtime.ts
@@ -1,0 +1,1174 @@
+/**
+ * Zero-dependency runtime for beasties.
+ *
+ * Consumes plans produced by `beasties/compiler` and evaluates them against
+ * rendered HTML using a single-pass token scanner (no DOM, no CSS parser).
+ * Selectors compiled to structural programs are matched exactly during the
+ * same pass, using the open-element stack for ancestor/sibling context.
+ * Suitable for per-request use in a server runtime (Nitro, workers, etc.).
+ */
+
+import type { AttrTest, CompiledRule, CompiledSheet, CompoundTest, SelectorMatch, StructuralProgram } from './compiler'
+import type { CompactPlan } from './plan'
+import { isCompactPlan } from './plan'
+import { decodePlan } from './plan-decode'
+
+export type { CompactPlan }
+export { decodePlan }
+
+export interface DocumentTokens {
+  tags: Set<string>
+  classes: Set<string>
+  ids: Set<string>
+  attrs: Set<string>
+  /** Exact results for structural programs evaluated during the scan */
+  matchedPrograms?: Map<StructuralProgram, boolean>
+}
+
+const VOID_ELEMENTS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+])
+
+const RAW_TEXT_ELEMENTS = new Set(['script', 'style', 'textarea', 'title', 'xmp'])
+
+const TAG_START_RE = /[a-z]/
+const TAG_NAME_END_RE = /[\s/>]/
+const ATTR_NAME_END_RE = /[\s=/>]/
+const WHITESPACE_RE = /\s/
+const CLASS_SPLIT_RE = /\s+/
+
+function createTokens(): DocumentTokens {
+  return {
+    tags: new Set(),
+    classes: new Set(),
+    ids: new Set(),
+    attrs: new Set(),
+  }
+}
+
+interface ScannedElement {
+  tag: string
+  id: string | null
+  classes: string[]
+  attrs: Array<[name: string, value: string | null]>
+}
+
+/**
+ * Flattened structural programs, prepared for evaluation. Positions are
+ * indices into `flat`; a program matches when its final compound matches.
+ *
+ * In avail/candidate lists, positions are encoded as `position << 1 | flag`,
+ * where the flag records whether every element matched so far sits strictly
+ * inside a beasties container (classic css-select bounds the whole selector,
+ * ancestors included, to the container subtree).
+ */
+interface PreparedPrograms {
+  programs: StructuralProgram[]
+  flat: Array<{ test: CompoundTest, edge: ' ' | '>' | '+' | '~' | null, last: boolean, program: number }>
+  /** anchor indices: start positions looked up by a token of their first compound */
+  byClass: Map<string, number[]>
+  byId: Map<string, number[]>
+  byTag: Map<string, number[]>
+  byAttr: Map<string, number[]>
+  universal: number[]
+}
+
+function preparePrograms(programs: StructuralProgram[]): PreparedPrograms {
+  const prepared: PreparedPrograms = {
+    programs,
+    flat: [],
+    byClass: new Map(),
+    byId: new Map(),
+    byTag: new Map(),
+    byAttr: new Map(),
+    universal: [],
+  }
+
+  for (let p = 0; p < programs.length; p++) {
+    const { compounds, combinators } = programs[p]!
+    const start = prepared.flat.length
+    for (let c = 0; c < compounds.length; c++) {
+      prepared.flat.push({
+        test: compounds[c]!,
+        edge: combinators[c] ?? null,
+        last: c === compounds.length - 1,
+        program: p,
+      })
+    }
+    const first = compounds[0]!
+    if (first.classes?.length) {
+      pushIndex(prepared.byClass, first.classes[0]!, start)
+    }
+    else if (first.ids?.length) {
+      pushIndex(prepared.byId, first.ids[0]!, start)
+    }
+    else if (first.tag) {
+      pushIndex(prepared.byTag, first.tag, start)
+    }
+    else if (first.attrs?.length) {
+      pushIndex(prepared.byAttr, first.attrs[0]!.name, start)
+    }
+    else {
+      prepared.universal.push(start)
+    }
+  }
+
+  return prepared
+}
+
+function pushIndex(map: Map<string, number[]>, key: string, position: number) {
+  const list = map.get(key)
+  if (list) {
+    list.push(position)
+  }
+  else {
+    map.set(key, [position])
+  }
+}
+
+function getAttrValue(element: ScannedElement, name: string): string | undefined {
+  for (const [attrName, value] of element.attrs) {
+    if (attrName === name) {
+      return value ?? ''
+    }
+  }
+  return undefined
+}
+
+function matchesAttr(test: AttrTest, element: ScannedElement): boolean {
+  let value = getAttrValue(element, test.name)
+  if (value === undefined) {
+    return false
+  }
+  if (test.action === 'exists') {
+    return true
+  }
+  let expected = test.value ?? ''
+  if (test.ignoreCase) {
+    value = value.toLowerCase()
+    expected = expected.toLowerCase()
+  }
+  switch (test.action) {
+    case 'equals':
+      return value === expected
+    case 'element':
+      return expected.length > 0 && value.split(CLASS_SPLIT_RE).includes(expected)
+    case 'start':
+      return expected.length > 0 && value.startsWith(expected)
+    case 'end':
+      return expected.length > 0 && value.endsWith(expected)
+    case 'any':
+      return expected.length > 0 && value.includes(expected)
+    case 'hyphen':
+      return value === expected || value.startsWith(`${expected}-`)
+  }
+  return false
+}
+
+function matchesCompound(test: CompoundTest, element: ScannedElement): boolean {
+  if (test.tag && test.tag !== element.tag) {
+    return false
+  }
+  if (test.ids) {
+    for (const id of test.ids) {
+      if (element.id !== id) {
+        return false
+      }
+    }
+  }
+  if (test.classes) {
+    for (const cls of test.classes) {
+      if (!element.classes.includes(cls)) {
+        return false
+      }
+    }
+  }
+  if (test.attrs) {
+    for (const attr of test.attrs) {
+      if (!matchesAttr(attr, element)) {
+        return false
+      }
+    }
+  }
+  return true
+}
+
+/**
+ * Per-open-element matcher state, holding the program positions available to
+ * this element's children and later siblings.
+ */
+interface ScanFrame {
+  /** this element is (or is inside) a beasties container */
+  container: boolean
+  /** positions reachable at any depth below (descendant edges) */
+  desc: number[]
+  /** positions reachable only by direct children (child edges) */
+  child: number[]
+  /** positions reachable only by the immediately-next child element */
+  adjacent: number[]
+  /** positions reachable by any later child element (general sibling edges) */
+  sibling: number[]
+}
+
+function createFrame(container: boolean, desc: number[], child: number[]): ScanFrame {
+  return { container, desc, child, adjacent: [], sibling: [] }
+}
+
+/**
+ * Scan HTML in a single pass, collecting the tag names, class names, ids and
+ * attribute names present in the document, and evaluating any structural
+ * programs against it. If `data-beasties-container` elements are present,
+ * only tokens (and program completions) within those subtrees count.
+ */
+export function scanHtml(html: string, programs?: StructuralProgram[]): DocumentTokens {
+  const lower = html.toLowerCase()
+  const all = createTokens()
+  const contained = createTokens()
+
+  const prepared = programs && programs.length > 0 ? preparePrograms(programs) : undefined
+  const matchedAll = prepared ? Array.from<boolean>({ length: prepared.programs.length }).fill(false) : []
+  const matchedContained = prepared ? Array.from<boolean>({ length: prepared.programs.length }).fill(false) : []
+  const candidateSet = new Set<number>()
+
+  let containerFound = false
+  const frames: ScanFrame[] = [createFrame(false, [], [])]
+
+  let i = 0
+  const length = html.length
+
+  while (i < length) {
+    i = lower.indexOf('<', i)
+    if (i === -1) {
+      break
+    }
+
+    const next = lower[i + 1]
+
+    if (next === '/') {
+      const end = lower.indexOf('>', i)
+      if (end === -1) {
+        break
+      }
+      if (frames.length > 1) {
+        frames.pop()
+      }
+      i = end + 1
+      continue
+    }
+
+    if (next === '!') {
+      if (lower.startsWith('<!--', i)) {
+        const end = lower.indexOf('-->', i + 4)
+        i = end === -1 ? length : end + 3
+      }
+      else {
+        const end = lower.indexOf('>', i)
+        i = end === -1 ? length : end + 1
+      }
+      continue
+    }
+
+    if (next === '?') {
+      const end = lower.indexOf('>', i)
+      i = end === -1 ? length : end + 1
+      continue
+    }
+
+    if (!next || !TAG_START_RE.test(next)) {
+      i++
+      continue
+    }
+
+    // parse tag name
+    let pos = i + 1
+    while (pos < length && !TAG_NAME_END_RE.test(lower[pos]!)) {
+      pos++
+    }
+    const tagName = lower.slice(i + 1, pos)
+
+    const element: ScannedElement = { tag: tagName, id: null, classes: [], attrs: [] }
+    let isContainer = false
+    let selfClosing = false
+
+    // parse attributes
+    while (pos < length) {
+      while (pos < length && WHITESPACE_RE.test(lower[pos]!)) {
+        pos++
+      }
+      if (lower[pos] === '/') {
+        selfClosing = true
+        pos++
+        continue
+      }
+      if (lower[pos] === '>' || pos >= length) {
+        break
+      }
+      selfClosing = false
+
+      const nameStart = pos
+      while (pos < length && !ATTR_NAME_END_RE.test(lower[pos]!)) {
+        pos++
+      }
+      const attrName = lower.slice(nameStart, pos)
+      let value: string | null = null
+
+      while (pos < length && WHITESPACE_RE.test(lower[pos]!)) {
+        pos++
+      }
+      if (lower[pos] === '=') {
+        pos++
+        while (pos < length && WHITESPACE_RE.test(lower[pos]!)) {
+          pos++
+        }
+        const quote = lower[pos]
+        if (quote === '"' || quote === '\'') {
+          const valueEnd = lower.indexOf(quote, pos + 1)
+          value = html.slice(pos + 1, valueEnd === -1 ? length : valueEnd)
+          pos = valueEnd === -1 ? length : valueEnd + 1
+        }
+        else {
+          const valueStart = pos
+          while (pos < length && !WHITESPACE_RE.test(lower[pos]!) && lower[pos] !== '>') {
+            pos++
+          }
+          value = html.slice(valueStart, pos)
+        }
+      }
+
+      if (attrName) {
+        element.attrs.push([attrName, value])
+        if (attrName === 'data-beasties-container') {
+          isContainer = true
+          containerFound = true
+        }
+        else if (attrName === 'class' && value !== null) {
+          for (const cls of value.trim().split(CLASS_SPLIT_RE)) {
+            if (cls) {
+              element.classes.push(cls)
+            }
+          }
+        }
+        else if (attrName === 'id' && value !== null) {
+          element.id = value.trim() || null
+        }
+      }
+    }
+
+    const frame = frames[frames.length - 1]!
+    const insideContainer = frame.container || isContainer
+
+    collectElement(all, element)
+    if (insideContainer) {
+      collectElement(contained, element)
+    }
+
+    let descOut: number[] | undefined
+    let childOut: number[] | undefined
+
+    if (prepared) {
+      // the container element itself doesn't participate in structural matching
+      const strictlyInside = frame.container
+
+      candidateSet.clear()
+      for (const list of [frame.desc, frame.child, frame.adjacent, frame.sibling]) {
+        for (const encoded of list) {
+          candidateSet.add(encoded)
+        }
+      }
+      addAnchoredStarts(candidateSet, prepared, element)
+
+      const adjacentOut: number[] = []
+      frame.adjacent = adjacentOut
+
+      for (const encoded of candidateSet) {
+        const position = encoded >> 1
+        const compound = prepared.flat[position]!
+        if (!matchesCompound(compound.test, element)) {
+          continue
+        }
+        const chainContained = (encoded & 1) === 1 && strictlyInside
+        if (compound.last) {
+          matchedAll[compound.program] = true
+          if (chainContained) {
+            matchedContained[compound.program] = true
+          }
+          continue
+        }
+        const nextEncoded = ((position + 1) << 1) | (chainContained ? 1 : 0)
+        switch (compound.edge) {
+          case ' ':
+            (descOut ??= []).push(nextEncoded)
+            break
+          case '>':
+            (childOut ??= []).push(nextEncoded)
+            break
+          case '+':
+            adjacentOut.push(nextEncoded)
+            break
+          case '~':
+            frame.sibling.push(nextEncoded)
+            break
+        }
+      }
+    }
+    else {
+      frame.adjacent = []
+    }
+
+    const isVoid = VOID_ELEMENTS.has(tagName) || selfClosing
+    const isRawText = RAW_TEXT_ELEMENTS.has(tagName)
+
+    if (!isVoid && !isRawText) {
+      frames.push(createFrame(
+        insideContainer,
+        descOut ? frame.desc.concat(descOut) : frame.desc,
+        childOut ?? [],
+      ))
+    }
+
+    i = lower[pos] === '>' ? pos + 1 : pos
+
+    if (!isVoid && isRawText) {
+      const close = lower.indexOf(`</${tagName}`, i)
+      if (close === -1) {
+        break
+      }
+      const end = lower.indexOf('>', close)
+      i = end === -1 ? length : end + 1
+    }
+  }
+
+  const tokens = containerFound ? contained : all
+  if (prepared) {
+    const matched = containerFound ? matchedContained : matchedAll
+    tokens.matchedPrograms = new Map()
+    for (let p = 0; p < prepared.programs.length; p++) {
+      tokens.matchedPrograms.set(prepared.programs[p]!, matched[p]!)
+    }
+  }
+  return tokens
+}
+
+function collectElement(tokens: DocumentTokens, element: ScannedElement) {
+  tokens.tags.add(element.tag)
+  if (element.id) {
+    tokens.ids.add(element.id)
+  }
+  for (const cls of element.classes) {
+    tokens.classes.add(cls)
+  }
+  for (const [name] of element.attrs) {
+    tokens.attrs.add(name)
+  }
+}
+
+// start positions are encoded with an optimistic contained flag; each element
+// in the chain (this one included) then ANDs its own containment into it
+function addAnchoredStarts(candidates: Set<number>, prepared: PreparedPrograms, element: ScannedElement) {
+  for (const cls of element.classes) {
+    const starts = prepared.byClass.get(cls)
+    if (starts) {
+      for (const position of starts) {
+        candidates.add((position << 1) | 1)
+      }
+    }
+  }
+  if (element.id) {
+    const starts = prepared.byId.get(element.id)
+    if (starts) {
+      for (const position of starts) {
+        candidates.add((position << 1) | 1)
+      }
+    }
+  }
+  const tagStarts = prepared.byTag.get(element.tag)
+  if (tagStarts) {
+    for (const position of tagStarts) {
+      candidates.add((position << 1) | 1)
+    }
+  }
+  for (const [name] of element.attrs) {
+    const starts = prepared.byAttr.get(name)
+    if (starts) {
+      for (const position of starts) {
+        candidates.add((position << 1) | 1)
+      }
+    }
+  }
+  for (const position of prepared.universal) {
+    candidates.add((position << 1) | 1)
+  }
+}
+
+function matchesCondition(condition: SelectorMatch, tokens: DocumentTokens): boolean {
+  if (condition === true) {
+    return true
+  }
+  if (condition.program) {
+    const exact = tokens.matchedPrograms?.get(condition.program)
+    if (exact !== undefined) {
+      return exact
+    }
+    // fall through to token checks when this program wasn't evaluated
+  }
+  if (condition.classes) {
+    for (const cls of condition.classes) {
+      if (!tokens.classes.has(cls)) {
+        return false
+      }
+    }
+  }
+  if (condition.ids) {
+    for (const id of condition.ids) {
+      if (!tokens.ids.has(id)) {
+        return false
+      }
+    }
+  }
+  if (condition.tags) {
+    for (const tag of condition.tags) {
+      if (!tokens.tags.has(tag)) {
+        return false
+      }
+    }
+  }
+  if (condition.attrs) {
+    for (const attr of condition.attrs) {
+      if (!tokens.attrs.has(attr)) {
+        return false
+      }
+    }
+  }
+  return true
+}
+
+/** Collect structural programs referenced by the compiled sheets */
+export function collectPrograms(sheets: CompiledSheet[]): StructuralProgram[] {
+  const programs: StructuralProgram[] = []
+  for (const sheet of sheets) {
+    for (const rule of sheet.rules) {
+      if (!rule.match) {
+        continue
+      }
+      for (const condition of rule.match) {
+        if (condition !== true && condition.program) {
+          programs.push(condition.program)
+        }
+      }
+    }
+  }
+  return programs
+}
+
+export interface RuntimeOptions {
+  /**
+   * Controls which keyframes rules are inlined _(default: `'critical'`)_
+   */
+  keyframes?: 'critical' | 'all' | 'none' | boolean
+  /**
+   * Inline critical font-face rules _(default: `false`)_
+   */
+  inlineFonts?: boolean
+  /**
+   * Preload critical fonts _(default: `true` when `fonts` is set)_
+   */
+  preloadFonts?: boolean
+  /**
+   * Shorthand for setting `inlineFonts` + `preloadFonts`
+   */
+  fonts?: boolean
+}
+
+export interface CriticalResult {
+  css: string
+  /** Font URLs that should be preloaded */
+  fontPreloads: string[]
+  /**
+   * The rules *not* inlined, i.e. what the external stylesheet still needs to
+   * provide. Only populated when `inverse` is requested.
+   */
+  inverseCss?: string
+}
+
+/**
+ * Evaluate a compiled sheet against scanned document tokens, producing the
+ * critical CSS subset.
+ */
+export function renderCriticalCss(sheet: CompiledSheet, tokens: DocumentTokens, options: RuntimeOptions & { inverse?: boolean } = {}): CriticalResult {
+  let keyframesMode = options.keyframes ?? 'critical'
+  if (keyframesMode === true) {
+    keyframesMode = 'all'
+  }
+  if (keyframesMode === false) {
+    keyframesMode = 'none'
+  }
+  const shouldPreloadFonts = options.fonts === true || options.preloadFonts === true
+  const shouldInlineFonts = options.fonts !== false && options.inlineFonts === true
+
+  const rules = sheet.rules
+  const texts: (string | null)[] = Array.from<string | null>({ length: rules.length }).fill(null)
+  const inverseTexts: (string | null)[] | undefined = options.inverse
+    ? Array.from<string | null>({ length: rules.length }).fill(null)
+    : undefined
+
+  let criticalFonts = ''
+  const criticalKeyframeNames = new Set<string>()
+  const fontPreloads: string[] = []
+  const preloadedFonts = new Set<string>()
+
+  // first pass: style rules
+  for (let i = 0; i < rules.length; i++) {
+    const rule = rules[i]!
+    if (rule.fontFace) {
+      if (rule.fontFace.src && shouldPreloadFonts && !preloadedFonts.has(rule.fontFace.src)) {
+        preloadedFonts.add(rule.fontFace.src)
+        fontPreloads.push(rule.fontFace.src.trim())
+      }
+      continue
+    }
+    if (rule.keyframes !== undefined) {
+      continue
+    }
+
+    const text = ruleText(rule, tokens)
+    if (inverseTexts) {
+      inverseTexts[i] = ruleText(rule, tokens, true)
+    }
+    if (text === null) {
+      continue
+    }
+    texts[i] = text
+
+    if (rule.fontsUsed) {
+      criticalFonts += ` ${rule.fontsUsed.join(' ')}`
+    }
+    if (rule.keyframesUsed) {
+      for (const name of rule.keyframesUsed) {
+        criticalKeyframeNames.add(name)
+      }
+    }
+  }
+
+  // second pass: @font-face and @keyframes, using usage data from the first
+  for (let i = 0; i < rules.length; i++) {
+    const rule = rules[i]!
+    if (rule.keyframes !== undefined) {
+      const keep = keyframesMode !== 'none' && (keyframesMode === 'all' || criticalKeyframeNames.has(rule.keyframes))
+      if (keep) {
+        texts[i] = rule.css ?? ''
+      }
+      else if (inverseTexts) {
+        inverseTexts[i] = rule.css ?? ''
+      }
+      continue
+    }
+    if (rule.fontFace) {
+      const { family, src } = rule.fontFace
+      if (shouldInlineFonts && family && src && criticalFonts.includes(family)) {
+        texts[i] = rule.css ?? ''
+      }
+      else if (inverseTexts) {
+        inverseTexts[i] = rule.css ?? ''
+      }
+    }
+  }
+
+  const result: CriticalResult = { css: assemble(texts, rules), fontPreloads }
+  if (inverseTexts) {
+    result.inverseCss = assemble(inverseTexts, rules)
+  }
+  return result
+}
+
+/** Emit every rule in the sheet, as when a stylesheet is inlined in full */
+export function renderFullCss(sheet: CompiledSheet): string {
+  return assemble(sheet.rules.map(wholeRuleText), sheet.rules)
+}
+
+function wholeRuleText(rule: CompiledRule): string {
+  if (rule.css !== undefined) {
+    return rule.css
+  }
+  return rule.selectors ? rule.selectors.join(',') + rule.body! : ''
+}
+
+/** Join rule texts, opening and closing at-rule wrappers as needed */
+function assemble(texts: (string | null)[], rules: CompiledRule[]): string {
+  const out: string[] = []
+  let openWrap: string[] = []
+  for (let i = 0; i < texts.length; i++) {
+    const text = texts[i]
+    if (text == null) {
+      continue
+    }
+    const wrap = rules[i]!.wrap ?? []
+    let common = 0
+    while (common < openWrap.length && common < wrap.length && openWrap[common] === wrap[common]) {
+      common++
+    }
+    for (let j = openWrap.length; j > common; j--) {
+      out.push('}')
+    }
+    for (let j = common; j < wrap.length; j++) {
+      out.push(wrap[j]!)
+    }
+    openWrap = wrap
+    out.push(text)
+  }
+  for (let j = openWrap.length; j > 0; j--) {
+    out.push('}')
+  }
+  return out.join('')
+}
+
+/**
+ * The rule's text as inlined, or `null` when it isn't. With `invert`, returns
+ * the complement instead: what the external stylesheet still has to provide.
+ */
+function ruleText(rule: CompiledRule, tokens: DocumentTokens, invert = false): string | null {
+  if (rule.always) {
+    return invert ? null : wholeRuleText(rule)
+  }
+  if (!rule.match) {
+    return invert ? null : rule.css ?? null
+  }
+  const body = rule.body
+  if (rule.selectors && body !== undefined) {
+    const kept = rule.selectors.filter((_, index) => matchesCondition(rule.match![index]!, tokens) !== invert)
+    if (kept.length === 0) {
+      return null
+    }
+    return kept.join(',') + body
+  }
+  if (rule.match.some(condition => matchesCondition(condition, tokens)) !== invert) {
+    return rule.css ?? ''
+  }
+  return null
+}
+
+/**
+ * The mechanism to use for lazy-loading stylesheets, mirroring the classic
+ * beasties `preload` option.
+ */
+export type PreloadStrategy = 'body' | 'media' | 'swap' | 'swap-high' | 'swap-low' | 'js' | 'js-lazy'
+
+export interface ProcessorOptions extends RuntimeOptions {
+  /**
+   * Which preload strategy to use for the original stylesheet links.
+   * _(default: move stylesheet links to the end of the document and insert preload links in their place)_
+   */
+  preload?: PreloadStrategy | false
+  /**
+   * Add `<noscript>` fallback to JS-based strategies _(default: `true`)_
+   */
+  noscriptFallback?: boolean
+  /**
+   * Cache rendered critical CSS keyed by the set of tokens found in the
+   * document, so pages with the same shape don't re-evaluate the compiled
+   * sheets _(default: `true`, keeping up to 100 entries)_
+   */
+  cache?: boolean | { maxSize?: number }
+  /**
+   * Inline stylesheets smaller than this many bytes in full, dropping their
+   * `<link>` entirely _(default: `0`, disabled)_
+   */
+  inlineThreshold?: number
+  /**
+   * If the rules left for the external stylesheet to provide would be below
+   * this many bytes, inline the stylesheet in full instead and drop its
+   * `<link>` _(default: `0`, disabled)_
+   */
+  minimumExternalSize?: number
+}
+
+const DEFAULT_CACHE_SIZE = 100
+
+/**
+ * Fingerprint the scanned tokens. Token sets iterate in insertion order,
+ * which is deterministic for a given document shape; a differently-ordered
+ * but equal set only costs a cache miss, never a wrong hit.
+ */
+function fingerprintTokens(tokens: DocumentTokens): string {
+  const parts: string[] = []
+  for (const set of [tokens.tags, tokens.classes, tokens.ids, tokens.attrs]) {
+    for (const token of set) {
+      parts.push(token)
+    }
+    parts.push('\n')
+  }
+  if (tokens.matchedPrograms) {
+    for (const matched of tokens.matchedPrograms.values()) {
+      parts.push(matched ? '1' : '0')
+    }
+  }
+  return parts.join(' ')
+}
+
+const LINK_TAG_RE = /<link\b(?:[^>"']|"[^"]*"|'[^']*')*>/gi
+const REL_STYLESHEET_RE = /\brel\s*=\s*(?:"stylesheet"|'stylesheet'|stylesheet(?=[\s>]))/i
+// conservative allowlist so a media attribute can be re-emitted into onload
+// javascript without any possibility of attribute or script breakout
+const SAFE_MEDIA_RE = /^[\w\s\-(),:.]+$/
+
+const CSS_LOADER_PREAMBLE = 'function $loadcss(u,m,l){(l=document.createElement(\'link\')).rel=\'stylesheet\';l.href=u;document.head.appendChild(l)}'
+const CSS_LOADER_LAZY_PREAMBLE = CSS_LOADER_PREAMBLE.replace(
+  'l.href',
+  'l.media=\'print\';l.onload=function(){l.media=m};l.href',
+)
+const CSS_LOADER_INVOKE = '$loadcss(document.currentScript.dataset.href,document.currentScript.dataset.media)'
+
+function attrValueRegex(name: string): RegExp {
+  return new RegExp(`(^|\\s)(${name})\\s*=\\s*("[^"]*"|'[^']*'|[^\\s>]+)`, 'i')
+}
+
+function attrNameRegex(name: string): RegExp {
+  return new RegExp(`(^|\\s)${name}(?=[\\s/>=])`, 'i')
+}
+
+function escapeAttr(value: string): string {
+  return value.replace(/"/g, '&quot;')
+}
+
+/** Get a (raw, un-decoded) attribute value from a tag string */
+function getAttr(tag: string, name: string): string | null {
+  const match = tag.match(attrValueRegex(name))
+  if (match) {
+    const raw = match[3]!
+    if (raw[0] === '"' || raw[0] === '\'') {
+      return raw.slice(1, -1)
+    }
+    return raw
+  }
+  return attrNameRegex(name).test(tag) ? '' : null
+}
+
+/** Set an attribute in a tag string, replacing in place or appending before `>` */
+function setAttr(tag: string, name: string, value: string): string {
+  const valueRe = attrValueRegex(name)
+  if (valueRe.test(tag)) {
+    return tag.replace(valueRe, `$1$2="${escapeAttr(value)}"`)
+  }
+  const nameRe = attrNameRegex(name)
+  if (nameRe.test(tag)) {
+    return tag.replace(nameRe, `$1${name}="${escapeAttr(value)}"`)
+  }
+  if (!tag.endsWith('>')) {
+    return tag
+  }
+  // scanned back rather than matched, since an anchored `/(\s*\/?)>$/` backtracks
+  // quadratically over whitespace runs earlier in the tag
+  let cut = tag.length - 1
+  if (tag[cut - 1] === '/') {
+    cut--
+  }
+  while (cut > 0 && WHITESPACE_RE.test(tag[cut - 1]!)) {
+    cut--
+  }
+  return `${tag.slice(0, cut)} ${name}="${escapeAttr(value)}"${tag.slice(cut)}`
+}
+
+/** Remove an attribute from a tag string */
+function removeAttr(tag: string, name: string): string {
+  return tag
+    .replace(attrValueRegex(name), '')
+    .replace(attrNameRegex(name), '')
+}
+
+function toPreload(tag: string): string {
+  return setAttr(setAttr(tag, 'rel', 'preload'), 'as', 'style')
+}
+
+// scanned rather than matched, since `/[?#].*$/` backtracks quadratically on a
+// href with many `?`/`#` characters
+function normalizeHref(href: string): string {
+  const query = href.indexOf('?')
+  const hash = href.indexOf('#')
+  let end = href.length
+  if (query !== -1) {
+    end = query
+  }
+  if (hash !== -1 && hash < end) {
+    end = hash
+  }
+  let start = 0
+  if (href[0] === '.' && href[1] === '/') {
+    start = 2
+  }
+  else if (href[0] === '/') {
+    start = 1
+  }
+  return href.slice(start, end)
+}
+
+function sheetForHref(sheets: CompiledSheet[], href: string): CompiledSheet | undefined {
+  const normalized = normalizeHref(href)
+  return sheets.find((sheet) => {
+    if (!sheet.href) {
+      return false
+    }
+    const sheetHref = normalizeHref(sheet.href)
+    return normalized === sheetHref || normalized.endsWith(`/${sheetHref}`)
+  })
+}
+
+interface Edit {
+  start: number
+  end: number
+  text: string
+}
+
+function applyEdits(html: string, edits: Edit[]): string {
+  edits.sort((a, b) => a.start - b.start || a.end - b.end)
+  let out = ''
+  let cursor = 0
+  for (const edit of edits) {
+    if (edit.start < cursor) {
+      continue
+    }
+    out += html.slice(cursor, edit.start) + edit.text
+    cursor = edit.end
+  }
+  return out + html.slice(cursor)
+}
+
+/**
+ * Create a `process(html)` function which inlines critical CSS from the
+ * compiled sheets into rendered HTML.
+ */
+export function createProcessor(plans: Array<CompiledSheet | CompactPlan>, options: ProcessorOptions = {}): {
+  process: (html: string) => string
+  extract: (html: string) => CriticalResult
+} {
+  const sheets = plans.map(plan => (isCompactPlan(plan) ? decodePlan(plan) : plan))
+  const programs = collectPrograms(sheets)
+
+  const cacheSize = options.cache === false ? 0 : (typeof options.cache === 'object' ? options.cache.maxSize ?? DEFAULT_CACHE_SIZE : DEFAULT_CACHE_SIZE)
+  const cache = cacheSize > 0 ? new Map<string, Map<CompiledSheet, CriticalResult>>() : undefined
+
+  // the inverse is only needed to compare against `minimumExternalSize`
+  const renderOptions = { ...options, inverse: !!options.minimumExternalSize }
+  const fullCssCache = new Map<CompiledSheet, string>()
+
+  function fullCss(sheet: CompiledSheet): string {
+    let css = fullCssCache.get(sheet)
+    if (css === undefined) {
+      css = renderFullCss(sheet)
+      fullCssCache.set(sheet, css)
+    }
+    return css
+  }
+
+  /**
+   * Whether the whole stylesheet should be inlined, making its `<link>`
+   * unnecessary: either it is small enough outright, or what would be left for
+   * it to serve is small enough that the request isn't worth saving.
+   */
+  function inlineInFull(sheet: CompiledSheet, critical: CriticalResult): boolean {
+    if (options.inlineThreshold && sheet.size < options.inlineThreshold) {
+      return true
+    }
+    if (options.minimumExternalSize && critical.inverseCss !== undefined) {
+      return critical.inverseCss.length < options.minimumExternalSize
+    }
+    return false
+  }
+
+  function renderSheet(sheet: CompiledSheet, tokens: DocumentTokens, key: string | undefined): CriticalResult {
+    if (!cache || key === undefined) {
+      return renderCriticalCss(sheet, tokens, renderOptions)
+    }
+    let bySheet = cache.get(key)
+    if (bySheet) {
+      // refresh recency
+      cache.delete(key)
+      cache.set(key, bySheet)
+    }
+    else {
+      bySheet = new Map()
+      cache.set(key, bySheet)
+      if (cache.size > cacheSize) {
+        cache.delete(cache.keys().next().value!)
+      }
+    }
+    let result = bySheet.get(sheet)
+    if (!result) {
+      result = renderCriticalCss(sheet, tokens, renderOptions)
+      bySheet.set(sheet, result)
+    }
+    return result
+  }
+
+  function extract(html: string): CriticalResult {
+    const tokens = scanHtml(html, programs)
+    const key = cache ? fingerprintTokens(tokens) : undefined
+    const css: string[] = []
+    const fontPreloads: string[] = []
+    for (const sheet of sheets) {
+      const result = renderSheet(sheet, tokens, key)
+      css.push(inlineInFull(sheet, result) ? fullCss(sheet) : result.css)
+      fontPreloads.push(...result.fontPreloads)
+    }
+    return { css: css.join(''), fontPreloads }
+  }
+
+  function process(html: string): string {
+    const tokens = scanHtml(html, programs)
+    const key = cache ? fingerprintTokens(tokens) : undefined
+    const strategy = options.preload
+
+    let firstLinkIndex = -1
+    const edits: Edit[] = []
+    const bodyAppends: string[] = []
+    const criticalParts: string[] = []
+    const fontPreloads = new Set<string>()
+    let isFirstSheet = true
+
+    for (const match of html.matchAll(LINK_TAG_RE)) {
+      const tag = match[0]
+      if (!REL_STYLESHEET_RE.test(tag)) {
+        continue
+      }
+      const href = getAttr(tag, 'href')
+      if (!href) {
+        continue
+      }
+      const sheet = sheetForHref(sheets, href)
+      if (!sheet) {
+        continue
+      }
+
+      const result = renderSheet(sheet, tokens, key)
+      const wholeSheet = inlineInFull(sheet, result)
+      criticalParts.push(wholeSheet ? fullCss(sheet) : result.css)
+      for (const preload of result.fontPreloads) {
+        fontPreloads.add(preload)
+      }
+
+      const start = match.index
+      const end = start + tag.length
+      if (firstLinkIndex === -1) {
+        firstLinkIndex = start
+      }
+
+      if (wholeSheet) {
+        // nothing left to load, so the link (and any loader for it) goes away
+        edits.push({ start, end, text: '' })
+        continue
+      }
+
+      if (strategy === false) {
+        continue
+      }
+
+      const rawMedia = getAttr(tag, 'media')
+      const media = rawMedia && SAFE_MEDIA_RE.test(rawMedia) ? rawMedia : undefined
+      let newTag = tag
+      let noscriptFallback = false
+      let scriptAfter: string | undefined
+
+      if (strategy === 'body') {
+        bodyAppends.push(tag)
+        newTag = ''
+      }
+      else if (strategy === 'media') {
+        newTag = setAttr(setAttr(tag, 'media', 'print'), 'onload', `this.media='${media || 'all'}'`)
+        noscriptFallback = true
+      }
+      else if (strategy === 'swap') {
+        newTag = toPreload(setAttr(tag, 'onload', 'this.rel=\'stylesheet\''))
+        noscriptFallback = true
+      }
+      else if (strategy === 'swap-high') {
+        newTag = setAttr(setAttr(setAttr(setAttr(tag, 'rel', 'alternate stylesheet preload'), 'title', 'styles'), 'as', 'style'), 'onload', 'this.title=\'\';this.rel=\'stylesheet\'')
+        noscriptFallback = true
+      }
+      else if (strategy === 'swap-low') {
+        newTag = setAttr(setAttr(setAttr(tag, 'rel', 'alternate stylesheet'), 'title', 'styles'), 'onload', 'this.title=\'\';this.rel=\'stylesheet\'')
+        noscriptFallback = true
+      }
+      else if (strategy === 'js' || strategy === 'js-lazy') {
+        const preamble = isFirstSheet ? (strategy === 'js-lazy' ? CSS_LOADER_LAZY_PREAMBLE : CSS_LOADER_PREAMBLE) : ''
+        scriptAfter = `<script data-href="${escapeAttr(href)}" data-media="${escapeAttr(media || 'all')}">${preamble}${CSS_LOADER_INVOKE}</script>`
+        newTag = toPreload(tag)
+        noscriptFallback = true
+      }
+      else {
+        // default: preload link in place, stylesheet link moved to end of body
+        bodyAppends.push(removeAttr(tag, 'id'))
+        newTag = toPreload(tag)
+      }
+
+      if (
+        options.noscriptFallback !== false
+        && noscriptFallback
+        // don't emit the URL inside <noscript> if it could terminate the block early
+        && !href.includes('</noscript>')
+      ) {
+        edits.push({ start: end, end, text: `<noscript>${removeAttr(tag, 'id')}</noscript>` })
+      }
+
+      if (scriptAfter) {
+        edits.push({ start: end, end, text: scriptAfter })
+      }
+
+      if (newTag !== tag) {
+        edits.push({ start, end, text: newTag })
+      }
+
+      isFirstSheet = false
+    }
+
+    const critical = criticalParts.join('')
+    if (!critical && fontPreloads.size === 0 && edits.length === 0 && bodyAppends.length === 0) {
+      return html
+    }
+
+    const headInsertions: string[] = []
+    for (const preload of fontPreloads) {
+      headInsertions.push(`<link rel="preload" as="font" crossorigin="anonymous" href="${escapeAttr(preload)}">`)
+    }
+    if (critical) {
+      headInsertions.push(`<style>${critical}</style>`)
+    }
+
+    if (headInsertions.length > 0) {
+      let insertAt = firstLinkIndex
+      if (insertAt === -1) {
+        const headClose = html.match(/<\/head\s*>/i)
+        insertAt = headClose?.index ?? 0
+      }
+      edits.push({ start: insertAt, end: insertAt, text: headInsertions.join('') })
+    }
+
+    if (bodyAppends.length > 0) {
+      const bodyClose = lastIndexOfRe(html, /<\/body\s*>/gi)
+      const insertAt = bodyClose === -1 ? html.length : bodyClose
+      edits.push({ start: insertAt, end: insertAt, text: bodyAppends.join('') })
+    }
+
+    return applyEdits(html, edits)
+  }
+
+  return { process, extract }
+}
+
+function lastIndexOfRe(html: string, re: RegExp): number {
+  let last = -1
+  for (const match of html.matchAll(re)) {
+    last = match.index
+  }
+  return last
+}

--- a/packages/beasties/src/selectors.ts
+++ b/packages/beasties/src/selectors.ts
@@ -1,0 +1,31 @@
+const removePseudoClassesAndElementsPattern = /(?<!\\)::?[a-z-]+(?:\(.+\))?/gi
+const implicitUniversalPattern = /([>+~])\s*(?!\1)([>+~])/g
+const emptyCombinatorPattern = /([>+~])\s*(?=\1|$)/g
+const removeTrailingCommasPattern = /\(\s*,|,\s*\)/g
+const BEFORE_AFTER_PSEUDO_RE = /^::?(?:before|after)$/
+
+/**
+ * Selectors that are considered critical regardless of whether they match an element in the document.
+ */
+export function isAlwaysCriticalSelector(sel: string): boolean {
+  return (
+    sel === ':root'
+    || sel === 'html'
+    || sel === 'body'
+    || (sel[0] === ':' && BEFORE_AFTER_PSEUDO_RE.test(sel))
+  )
+}
+
+/**
+ * Strip pseudo-classes and pseudo-elements from a selector so it can be
+ * matched against the document, since we only care that the associated
+ * elements exist.
+ */
+export function normalizeCssSelector(sel: string): string {
+  return sel
+    .replace(removePseudoClassesAndElementsPattern, '')
+    .replace(removeTrailingCommasPattern, match => (match.includes('(') ? '(' : ')'))
+    .replace(implicitUniversalPattern, '$1 * $2')
+    .replace(emptyCombinatorPattern, '$1 *')
+    .trim()
+}

--- a/packages/beasties/src/urls.ts
+++ b/packages/beasties/src/urls.ts
@@ -1,0 +1,46 @@
+import path from 'node:path'
+
+export const REMOTE_URL_RE: RegExp = /^https?:\/\//
+// unquoted urls cannot contain unescaped parentheses, and excluding them keeps
+// backtracking linear on input like `url((((...`
+const URL_RE_G = /url\((?:'([^']*)'|"([^"]*)"|([^()]*))\)/gi
+const ABSOLUTE_URL_RE = /^(?:[a-z][\w+.-]*:|\/\/|\/|#)/i
+
+/**
+ * Resolve a `url()` value that is relative to `baseHref` (the location of the
+ * stylesheet it was declared in) so that it can be used from the document instead.
+ */
+export function resolveCssUrl(url: string, baseHref: string): string {
+  if (!url || ABSOLUTE_URL_RE.test(url)) {
+    return url
+  }
+
+  const base = baseHref.split('?')[0]!.split('#')[0]!
+
+  if (REMOTE_URL_RE.test(base) || base.startsWith('//')) {
+    try {
+      const resolved = new URL(url, base.startsWith('//') ? `https:${base}` : base)
+      return base.startsWith('//') ? resolved.href.replace(REMOTE_URL_RE, '//') : resolved.href
+    }
+    catch {
+      return url
+    }
+  }
+
+  const dir = path.posix.dirname(base)
+  // the stylesheet sits alongside the document, so relative urls already resolve correctly
+  if (dir === '.' || dir === '') {
+    return url
+  }
+
+  return path.posix.join(dir, url)
+}
+
+export function rewriteCssUrls(css: string, baseHref: string): string {
+  return css.replace(URL_RE_G, (match, singleQuoted?: string, doubleQuoted?: string, bare?: string) => {
+    const quote = singleQuoted !== undefined ? '\'' : doubleQuoted !== undefined ? '"' : ''
+    const url = singleQuoted ?? doubleQuoted ?? bare?.trim() ?? ''
+    const resolved = resolveCssUrl(url, baseHref)
+    return resolved === url ? match : `url(${quote}${resolved}${quote})`
+  })
+}

--- a/packages/beasties/test/compiled.test.ts
+++ b/packages/beasties/test/compiled.test.ts
@@ -1,0 +1,758 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+import { compileSheet } from '../src/compiler'
+import Beasties from '../src/index'
+import { collectPrograms, createProcessor, renderCriticalCss, scanHtml } from '../src/runtime'
+
+const fixtureDir = fileURLToPath(new URL('./src', import.meta.url))
+
+function trim(s: TemplateStringsArray) {
+  return s[0]!
+    .trim()
+    .replace(new RegExp(`^${s[0]!.match(/^( {2}|\t)+/m)![0]}`, 'gm'), '')
+}
+
+/** run classic beasties over html with in-memory css assets, returning the inlined critical css */
+async function classicCritical(html: string, css: string, options: ConstructorParameters<typeof Beasties>[0] = {}): Promise<string> {
+  const beasties = new Beasties({
+    reduceInlineStyles: false,
+    path: '/',
+    logLevel: 'silent',
+    preload: false,
+    ...options,
+  })
+  beasties.readFile = () => css
+  const result = await beasties.process(html)
+  const styles = [...result.matchAll(/<style>([\s\S]*?)<\/style>/g)].map(m => m[1])
+  return styles.join('')
+}
+
+function compiledCritical(html: string, css: string, options: Parameters<typeof renderCriticalCss>[2] = {}, compileOptions: Parameters<typeof compileSheet>[1] = {}): string {
+  const sheet = compileSheet(css, compileOptions)
+  return renderCriticalCss(sheet, scanHtml(html, collectPrograms([sheet])), options).css
+}
+
+const BASIC_HTML = trim`
+  <html>
+    <head>
+      <link rel="stylesheet" href="/style.css">
+    </head>
+    <body>
+      <h1>Hello World!</h1>
+      <p class="para">This is a paragraph</p>
+      <div id="app" data-x="1"><span class="a b">nested</span></div>
+    </body>
+  </html>
+`
+
+describe('compiled beasties (compiler + runtime)', () => {
+  describe('parity with classic process()', () => {
+    it('matches on basic selectors', async () => {
+      const css = trim`
+        h1 { color: blue; }
+        h2.unused { color: red; }
+        p { color: purple; }
+        p.unused { color: orange; }
+        .para { margin: 0; }
+        #app { display: flex; }
+        #missing { display: none; }
+        [data-x] { color: teal; }
+        [data-missing] { color: tomato; }
+        span.a.b { color: green; }
+        span.a.c { color: yellow; }
+      `
+      const classic = await classicCritical(BASIC_HTML, css)
+      const compiled = compiledCritical(BASIC_HTML, css)
+      expect(compiled).toBe(classic)
+      expect(compiled).toMatchInlineSnapshot(`"h1{color:blue}p{color:purple}.para{margin:0}#app{display:flex}[data-x]{color:teal}span.a.b{color:green}"`)
+    })
+
+    it('matches on the styles.css fixture (with data-beasties-container)', async () => {
+      const html = fs.readFileSync(path.join(fixtureDir, 'index.html'), 'utf-8')
+      const css = fs.readFileSync(path.join(fixtureDir, 'styles.css'), 'utf-8')
+      const classic = await classicCritical(html, css)
+      const compiled = compiledCritical(html, css)
+      expect(compiled).toBe(classic)
+    })
+
+    it('matches for media queries and empty at-rule removal', async () => {
+      const css = trim`
+        @media (min-width: 40em) {
+          h1 { font-size: 3em; }
+          .unused { color: red; }
+        }
+        @media print {
+          .unused { display: none; }
+        }
+        @supports (display: grid) {
+          #app { display: grid; }
+        }
+        h1 { color: blue; }
+      `
+      const classic = await classicCritical(BASIC_HTML, css)
+      const compiled = compiledCritical(BASIC_HTML, css)
+      expect(compiled).toBe(classic)
+      expect(compiled).toContain('@media (min-width: 40em) {h1{font-size:3em}}')
+      expect(compiled).not.toContain('print')
+    })
+
+    it('preserves empty @layer blocks and layer statements', async () => {
+      const css = trim`
+        @layer a, b;
+        @layer base {
+          .unused { color: red; }
+        }
+        @layer components {
+          h1 { color: blue; }
+        }
+      `
+      const classic = await classicCritical(BASIC_HTML, css)
+      const compiled = compiledCritical(BASIC_HTML, css)
+      expect(compiled).toBe(classic)
+      expect(compiled).toContain('@layer a, b;')
+      expect(compiled).toContain('@layer base {}')
+    })
+
+    it('matches for beasties comment markers', async () => {
+      const css = trim`
+        /* beasties:exclude */
+        h1 { color: blue; }
+        /* beasties:include */
+        .not-present { color: red; }
+        /* beasties:exclude start */
+        p { color: purple; }
+        .para { margin: 0; }
+        /* beasties:exclude end */
+        #app { display: flex; }
+      `
+      const classic = await classicCritical(BASIC_HTML, css)
+      const compiled = compiledCritical(BASIC_HTML, css)
+      expect(compiled).toBe(classic)
+      expect(compiled).toBe('.not-present{color:red}#app{display:flex}')
+    })
+
+    it('matches for allowRules', async () => {
+      const css = trim`
+        .always-inline { color: red; }
+        .regex-match-1 { color: green; }
+        .unused { color: blue; }
+      `
+      const allowRules = ['.always-inline', /^\.regex-match/]
+      const classic = await classicCritical(BASIC_HTML, css, { allowRules })
+      const sheet = compileSheet(css, { allowRules })
+      const compiled = renderCriticalCss(sheet, scanHtml(BASIC_HTML), {}).css
+      expect(compiled).toBe(classic)
+      expect(compiled).toBe('.always-inline{color:red}.regex-match-1{color:green}')
+    })
+
+    it('matches for critical keyframes', async () => {
+      const css = trim`
+        h1 { animation: fade 1s ease infinite; }
+        .unused { animation: spin 1s linear; }
+        @keyframes fade { from { opacity: 0 } to { opacity: 1 } }
+        @keyframes spin { to { transform: rotate(360deg) } }
+      `
+      const classic = await classicCritical(BASIC_HTML, css)
+      const compiled = compiledCritical(BASIC_HTML, css)
+      expect(compiled).toBe(classic)
+      expect(compiled).toContain('@keyframes fade')
+      expect(compiled).not.toContain('@keyframes spin')
+
+      const none = compiledCritical(BASIC_HTML, css, { keyframes: 'none' })
+      expect(none).not.toContain('@keyframes')
+      const allKeyframes = compiledCritical(BASIC_HTML, css, { keyframes: 'all' })
+      expect(allKeyframes).toContain('@keyframes spin')
+    })
+
+    it('matches for critical font inlining', async () => {
+      const css = trim`
+        h1 { font-family: CriticalFont, sans-serif; }
+        .unused { font-family: UnusedFont; }
+        @font-face { font-family: CriticalFont; src: url(/fonts/critical.woff2); }
+        @font-face { font-family: UnusedFont; src: url(/fonts/unused.woff2); }
+      `
+      const options = { inlineFonts: true, preloadFonts: false }
+      const classic = await classicCritical(BASIC_HTML, css, options)
+      const compiled = compiledCritical(BASIC_HTML, css, options)
+      expect(compiled).toBe(classic)
+      expect(compiled).toContain('CriticalFont')
+      expect(compiled).not.toContain('UnusedFont')
+    })
+
+    it('matches for pseudo-class and pseudo-element selectors', async () => {
+      const css = trim`
+        h1:hover { color: red; }
+        .para::first-line { font-weight: bold; }
+        ::selection { background: gold; }
+        .missing:focus { outline: none; }
+        div:is(:hover, .unused) { color: teal; }
+      `
+      const classic = await classicCritical(BASIC_HTML, css)
+      const compiled = compiledCritical(BASIC_HTML, css)
+      expect(compiled).toBe(classic)
+    })
+  })
+
+  describe('structural matching', () => {
+    it('matches classic for combinator rules whose parts exist but do not match structurally', async () => {
+      const html = trim`
+        <html><head><link rel="stylesheet" href="/style.css"></head><body>
+          <div class="a"><span>x</span></div>
+          <div class="b">y</div>
+        </body></html>
+      `
+      const css = trim`
+        .a .b { color: red; }
+        .a > .b { color: green; }
+        .a .missing { color: blue; }
+      `
+      const classic = await classicCritical(html, css)
+      const compiled = compiledCritical(html, css)
+      expect(classic).toBe('')
+      expect(compiled).toBe(classic)
+
+      // token-only mode keeps the two where every part exists somewhere
+      const tokenMode = compiledCritical(html, css, {}, { exact: false })
+      expect(tokenMode).toBe('.a .b{color:red}.a > .b{color:green}')
+    })
+
+    it('matches descendant and child combinators exactly', async () => {
+      const html = trim`
+        <html><head><link rel="stylesheet" href="/style.css"></head><body>
+          <div class="a"><p><span class="b">deep</span></p></div>
+          <em class="c">outside</em>
+        </body></html>
+      `
+      const css = trim`
+        .a .b { color: red; }
+        .a > .b { color: green; }
+        .a > p > .b { color: blue; }
+        .a .c { color: cyan; }
+        body .a { color: black; }
+      `
+      const classic = await classicCritical(html, css)
+      const compiled = compiledCritical(html, css)
+      expect(compiled).toBe(classic)
+      expect(compiled).toBe('.a .b{color:red}.a > p > .b{color:blue}body .a{color:black}')
+    })
+
+    it('matches sibling combinators exactly', async () => {
+      const html = trim`
+        <html><head><link rel="stylesheet" href="/style.css"></head><body>
+          <p class="x">1</p>
+          <span class="y">2</span>
+          <i class="z">3</i>
+        </body></html>
+      `
+      const css = trim`
+        .x + .y { color: red; }
+        .y + .x { color: green; }
+        .x ~ .z { color: blue; }
+        .z ~ .x { color: cyan; }
+        .x + .z { color: magenta; }
+      `
+      const classic = await classicCritical(html, css)
+      const compiled = compiledCritical(html, css)
+      expect(compiled).toBe(classic)
+      expect(compiled).toBe('.x + .y{color:red}.x ~ .z{color:blue}')
+    })
+
+    it('matches compound co-occurrence exactly', async () => {
+      const html = trim`
+        <html><head><link rel="stylesheet" href="/style.css"></head><body>
+          <div class="a">1</div>
+          <div class="b">2</div>
+          <span class="c d">3</span>
+        </body></html>
+      `
+      const css = trim`
+        .a.b { color: red; }
+        .c.d { color: green; }
+        span.c { color: blue; }
+        div.c { color: cyan; }
+      `
+      const classic = await classicCritical(html, css)
+      const compiled = compiledCritical(html, css)
+      expect(compiled).toBe(classic)
+      expect(compiled).toBe('.c.d{color:green}span.c{color:blue}')
+    })
+
+    it('matches attribute value selectors exactly', async () => {
+      const html = trim`
+        <html><head><link rel="stylesheet" href="/style.css"></head><body>
+          <div data-theme="dark" data-size="large-screen" lang="en-GB">x</div>
+        </body></html>
+      `
+      const css = trim`
+        [data-theme="dark"] { color: red; }
+        [data-theme="light"] { color: green; }
+        [data-size^="large"] { color: blue; }
+        [data-size$="screen"] { color: cyan; }
+        [data-size*="e-s"] { color: magenta; }
+        [lang|="en"] { color: yellow; }
+        [lang|="fr"] { color: black; }
+      `
+      const classic = await classicCritical(html, css)
+      const compiled = compiledCritical(html, css)
+      expect(compiled).toBe(classic)
+      expect(compiled).toBe('[data-theme="dark"]{color:red}[data-size^="large"]{color:blue}[data-size$="screen"]{color:cyan}[data-size*="e-s"]{color:magenta}[lang|="en"]{color:yellow}')
+    })
+
+    it('bounds structural matching to the container subtree', async () => {
+      const html = trim`
+        <html><head><link rel="stylesheet" href="/style.css"></head><body>
+          <div class="wrapper">
+            <main class="scope" data-beasties-container>
+              <div class="row"><span class="cell">x</span></div>
+            </main>
+          </div>
+        </body></html>
+      `
+      const css = trim`
+        .row .cell { color: red; }
+        .wrapper .cell { color: green; }
+        main .cell { color: blue; }
+        .scope .cell { color: cyan; }
+      `
+      const classic = await classicCritical(html, css)
+      const compiled = compiledCritical(html, css)
+      expect(compiled).toBe(classic)
+      // only chains lying strictly inside the container match; ancestors
+      // outside it (and the container element itself) don't count
+      expect(compiled).toBe('.row .cell{color:red}')
+    })
+
+    it('survives JSON round-tripping of programs', () => {
+      const html = '<html><body><div class="a"><span class="b">x</span></div></body></html>'
+      const sheet: ReturnType<typeof compileSheet> = JSON.parse(JSON.stringify(compileSheet('.a .b { color: red } .b .a { color: green }')))
+      const tokens = scanHtml(html, collectPrograms([sheet]))
+      expect(renderCriticalCss(sheet, tokens, {}).css).toBe('.a .b{color:red}')
+    })
+
+    it('never drops a rule that classic would keep', async () => {
+      const html = fs.readFileSync(path.join(fixtureDir, 'index.html'), 'utf-8')
+      const css = fs.readFileSync(path.join(fixtureDir, 'styles.css'), 'utf-8')
+      const classic = await classicCritical(html, css)
+      const compiled = compiledCritical(html, css)
+      for (const rule of classic.split('}').filter(Boolean)) {
+        expect(compiled).toContain(rule)
+      }
+    })
+  })
+
+  describe('pathological input', () => {
+    const sheet = () => compileSheet('h1 { color: blue; }', { href: 'style.css' })
+
+    it('handles long whitespace runs inside a link tag in linear time', () => {
+      const { process } = createProcessor([sheet()], { preload: 'swap' })
+      const html = `<html><head><link href="/style.css" rel="stylesheet"${' '.repeat(64_000)}data-x="1"></head><body><h1>hi</h1></body></html>`
+
+      const start = performance.now()
+      const result = process(html)
+      expect(performance.now() - start).toBeLessThan(500)
+
+      expect(result).toContain('<style>h1{color:blue}</style>')
+      expect(result).toContain('rel="preload"')
+    })
+
+    it('handles hrefs with many query and hash characters in linear time', () => {
+      const { process } = createProcessor([sheet()])
+      const html = `<html><head><link href="/style.css?${'#'.repeat(64_000)}\n" rel="stylesheet"></head><body><h1>hi</h1></body></html>`
+
+      const start = performance.now()
+      const result = process(html)
+      expect(performance.now() - start).toBeLessThan(500)
+
+      expect(result).toContain('<style>h1{color:blue}</style>')
+    })
+
+    it('appends an attribute to tags with unusual endings', () => {
+      const { process } = createProcessor([sheet()], { preload: 'media' })
+      for (const [tag, expected] of [
+        ['<link rel="stylesheet" href="/style.css">', '<link rel="stylesheet" href="/style.css" media="print" onload'],
+        ['<link rel="stylesheet" href="/style.css"/>', '<link rel="stylesheet" href="/style.css" media="print" onload'],
+        ['<link rel="stylesheet" href="/style.css"  />', '<link rel="stylesheet" href="/style.css" media="print" onload'],
+      ]) {
+        const result = process(`<html><head>${tag}</head><body><h1>hi</h1></body></html>`)
+        expect(result, tag).toContain(expected)
+      }
+    })
+  })
+
+  describe('scanHtml', () => {
+    it('collects tags, classes, ids and attributes', () => {
+      const tokens = scanHtml(BASIC_HTML)
+      expect(tokens.tags).toContain('h1')
+      expect(tokens.classes).toContain('para')
+      expect(tokens.classes).toContain('a')
+      expect(tokens.classes).toContain('b')
+      expect(tokens.ids).toContain('app')
+      expect(tokens.attrs).toContain('data-x')
+    })
+
+    it('ignores raw text content and comments', () => {
+      const tokens = scanHtml(trim`
+        <html><body>
+        <!-- <div class="commented"></div> -->
+        <script>const html = '<div class="scripted"></div>'</script>
+        <style>.styled { color: red }</style>
+        <textarea><div class="textarea-content"></div></textarea>
+        <div class="real"></div>
+        </body></html>
+      `)
+      expect(tokens.classes).toContain('real')
+      expect(tokens.classes).not.toContain('commented')
+      expect(tokens.classes).not.toContain('scripted')
+      expect(tokens.classes).not.toContain('textarea-content')
+    })
+
+    it('scopes tokens to data-beasties-container', () => {
+      const tokens = scanHtml(trim`
+        <html><body>
+        <div class="outside"></div>
+        <main data-beasties-container class="on-container">
+          <div class="inside"><span id="inner-id"></span></div>
+        </main>
+        <footer class="also-outside"></footer>
+        </body></html>
+      `)
+      expect(tokens.classes).toContain('inside')
+      expect(tokens.classes).toContain('on-container')
+      expect(tokens.ids).toContain('inner-id')
+      expect(tokens.classes).not.toContain('outside')
+      expect(tokens.classes).not.toContain('also-outside')
+    })
+  })
+
+  describe('whole-sheet inlining', () => {
+    const CSS = trim`
+      h1 { color: blue; }
+      .unused { color: red; }
+      @keyframes unused-spin { to { opacity: 1 } }
+    `
+
+    function classic(options: ConstructorParameters<typeof Beasties>[0]) {
+      const beasties = new Beasties({ reduceInlineStyles: false, path: '/', logLevel: 'silent', ...options })
+      beasties.readFile = () => CSS
+      return beasties.process(BASIC_HTML)
+    }
+
+    function compiled(options: Parameters<typeof createProcessor>[1]) {
+      return createProcessor([compileSheet(CSS, { href: 'style.css' })], options).process(BASIC_HTML)
+    }
+
+    it('inlines a stylesheet below inlineThreshold in full and drops its link', async () => {
+      const result = compiled({ inlineThreshold: 1000 })
+      // everything, including rules and keyframes that aren't critical
+      expect(result).toContain('<style>h1{color:blue}.unused{color:red}@keyframes unused-spin {to{opacity:1}}</style>')
+      expect(result).not.toContain('<link')
+      expect(result).not.toContain('<noscript>')
+
+      const classicResult = await classic({ inlineThreshold: 1000 })
+      expect(classicResult).not.toContain('<link')
+      expect(classicResult).toContain('.unused')
+      expect(classicResult).toContain('unused-spin')
+    })
+
+    it('prunes as usual when the stylesheet is above inlineThreshold', async () => {
+      const result = compiled({ inlineThreshold: 10, preload: false })
+      expect(result).toContain('<style>h1{color:blue}</style>')
+      expect(result).toContain('<link rel="stylesheet" href="/style.css">')
+
+      const classicResult = await classic({ inlineThreshold: 10, preload: false })
+      expect(classicResult).toContain('<link rel="stylesheet" href="/style.css">')
+      expect(classicResult).not.toContain('.unused')
+    })
+
+    it('inlines in full when what is left for the stylesheet is below minimumExternalSize', () => {
+      const result = compiled({ minimumExternalSize: 1000 })
+      expect(result).toContain('.unused{color:red}')
+      expect(result).toContain('unused-spin')
+      expect(result).not.toContain('<link')
+    })
+
+    it('keeps the stylesheet when the remainder is above minimumExternalSize', () => {
+      const result = compiled({ minimumExternalSize: 10, preload: false })
+      expect(result).toContain('<style>h1{color:blue}</style>')
+      expect(result).toContain('<link rel="stylesheet" href="/style.css">')
+    })
+
+    it('measures the remainder, not the whole stylesheet', () => {
+      const sheet = compileSheet(CSS, { href: 'style.css' })
+      const tokens = scanHtml(BASIC_HTML, collectPrograms([sheet]))
+      const { css, inverseCss } = renderCriticalCss(sheet, tokens, { inverse: true })
+      expect(css).toBe('h1{color:blue}')
+      expect(inverseCss).toBe('.unused{color:red}@keyframes unused-spin {to{opacity:1}}')
+
+      // a threshold between the remainder and the full sheet inlines in full
+      const between = inverseCss!.length + 1
+      expect(compiled({ minimumExternalSize: between })).not.toContain('<link')
+      expect(compiled({ minimumExternalSize: inverseCss!.length })).toContain('<link')
+    })
+
+    it('overrides any preload strategy for the inlined sheet', () => {
+      for (const preload of ['js', 'media', 'swap', 'body', undefined] as const) {
+        const result = compiled({ inlineThreshold: 1000, preload })
+        expect(result, String(preload)).not.toContain('<link')
+        expect(result, String(preload)).not.toContain('<script')
+        expect(result, String(preload)).not.toContain('<noscript>')
+      }
+    })
+
+    it('applies per stylesheet', () => {
+      const small = compileSheet('h1 { color: blue; } .unused-small { color: red; }', { href: 'small.css' })
+      const big = compileSheet(`.lead { color: teal; }${' '.repeat(500)}.unused-big { color: red; }`, { href: 'big.css' })
+      const html = BASIC_HTML.replace(
+        '<link rel="stylesheet" href="/style.css">',
+        '<link rel="stylesheet" href="/small.css"><link rel="stylesheet" href="/big.css">',
+      )
+      const result = createProcessor([small, big], { inlineThreshold: 100, preload: false }).process(html)
+      expect(result).toContain('.unused-small{color:red}')
+      expect(result).not.toContain('.unused-big')
+      expect(result).not.toContain('small.css')
+      expect(result).toContain('<link rel="stylesheet" href="/big.css">')
+    })
+
+    it('is reflected by extract()', () => {
+      const { extract } = createProcessor([compileSheet(CSS, { href: 'style.css' })], { inlineThreshold: 1000 })
+      expect(extract(BASIC_HTML).css).toContain('.unused{color:red}')
+    })
+
+    it('still preloads fonts for a fully inlined sheet', () => {
+      const css = trim`
+        h1 { font-family: MyFont; }
+        @font-face { font-family: MyFont; src: url(/fonts/my.woff2); }
+      `
+      const { process } = createProcessor([compileSheet(css, { href: 'style.css' })], { inlineThreshold: 1000, fonts: true })
+      const result = process(BASIC_HTML)
+      expect(result).toContain('<link rel="preload" as="font" crossorigin="anonymous" href="/fonts/my.woff2">')
+      expect(result).not.toContain('rel="stylesheet"')
+    })
+  })
+
+  describe('url() rebasing', () => {
+    const CSS = trim`
+      h1 { background: url(bg.png); }
+      .lead { background: url("../img/a.png"); }
+      p { background: url(/absolute.png); }
+      div { background: url(https://cdn.example.com/remote.png); }
+      @font-face { font-family: MyFont; src: url(fonts/my.woff2); }
+      .lead { font-family: MyFont; }
+    `
+    const HTML = trim`
+      <html>
+        <head><link rel="stylesheet" href="/assets/css/style.css"></head>
+        <body><h1>hi</h1><p>p</p><div class="lead">l</div></body>
+      </html>
+    `
+
+    it('rebases relative urls against the stylesheet location', async () => {
+      const beasties = new Beasties({ reduceInlineStyles: false, path: '/', logLevel: 'silent', preload: false, inlineFonts: true, preloadFonts: false })
+      beasties.readFile = () => CSS
+      const classicCss = (await beasties.process(HTML)).match(/<style>([\s\S]*?)<\/style>/)![1]
+
+      const sheet = compileSheet(CSS, { href: '/assets/css/style.css' })
+      const compiledCss = renderCriticalCss(sheet, scanHtml(HTML, collectPrograms([sheet])), { inlineFonts: true, preloadFonts: false }).css
+
+      expect(compiledCss).toBe(classicCss)
+      expect(compiledCss).toContain('url(/assets/css/bg.png)')
+      expect(compiledCss).toContain('url("/assets/img/a.png")')
+      expect(compiledCss).toContain('url(/absolute.png)')
+      expect(compiledCss).toContain('url(https://cdn.example.com/remote.png)')
+      expect(compiledCss).toContain('url(/assets/css/fonts/my.woff2)')
+    })
+
+    it('rebases font preload hrefs', () => {
+      const sheet = compileSheet(CSS, { href: '/assets/css/style.css' })
+      const { fontPreloads } = renderCriticalCss(sheet, scanHtml(HTML, collectPrograms([sheet])), { fonts: true })
+      expect(fontPreloads).toEqual(['/assets/css/fonts/my.woff2'])
+    })
+
+    it('leaves urls alone when the sheet sits alongside the document', () => {
+      const sheet = compileSheet('h1 { background: url(bg.png) }', { href: 'style.css' })
+      expect(renderCriticalCss(sheet, scanHtml(HTML, collectPrograms([sheet])), {}).css).toBe('h1{background:url(bg.png)}')
+    })
+  })
+
+  describe('createProcessor', () => {
+    const makeProcessor = (options: Parameters<typeof createProcessor>[1] = {}, css = 'h1 { color: blue; }\n.unused { color: red; }') =>
+      createProcessor([compileSheet(css, { href: 'style.css' })], options)
+
+    it('inlines critical css for matching stylesheet links', () => {
+      const { process } = makeProcessor({ preload: false })
+      const result = process(BASIC_HTML)
+      expect(result).toContain('<style>h1{color:blue}</style><link rel="stylesheet" href="/style.css">')
+      expect(result).not.toContain('onload=')
+      expect(result).not.toContain('<noscript>')
+    })
+
+    it('uses the default preload strategy correctly', () => {
+      const { process } = makeProcessor()
+      const result = process(BASIC_HTML)
+      expect(result).toContain('<style>h1{color:blue}</style><link rel="preload" href="/style.css" as="style">')
+      expect(result).toContain('<link rel="stylesheet" href="/style.css"></body>')
+      expect(result).not.toContain('<noscript>')
+    })
+
+    it('uses the "body" preload strategy correctly', () => {
+      const { process } = makeProcessor({ preload: 'body' })
+      const result = process(BASIC_HTML)
+      expect(result).toContain('<style>h1{color:blue}</style>')
+      expect(result).toContain('<link rel="stylesheet" href="/style.css"></body>')
+      expect(result.match(/<link/g)).toHaveLength(1)
+    })
+
+    it('uses the "media" preload strategy correctly', () => {
+      const { process } = makeProcessor({ preload: 'media' })
+      const result = process(BASIC_HTML)
+      expect(result).toContain(`<link rel="stylesheet" href="/style.css" media="print" onload="this.media='all'">`)
+      expect(result).toContain('<noscript><link rel="stylesheet" href="/style.css"></noscript>')
+      expect(result).toContain('<style>h1{color:blue}</style>')
+    })
+
+    it('uses the "swap" preload strategy correctly', () => {
+      const { process } = makeProcessor({ preload: 'swap' })
+      const result = process(BASIC_HTML)
+      expect(result).toContain(`<link rel="preload" href="/style.css" onload="this.rel='stylesheet'" as="style">`)
+      expect(result).toContain('<noscript><link rel="stylesheet" href="/style.css"></noscript>')
+    })
+
+    it('uses the "swap-high" preload strategy correctly', () => {
+      const { process } = makeProcessor({ preload: 'swap-high' })
+      const result = process(BASIC_HTML)
+      expect(result).toContain(`<link rel="alternate stylesheet preload" href="/style.css" title="styles" as="style" onload="this.title='';this.rel='stylesheet'">`)
+      expect(result).toContain('<noscript><link rel="stylesheet" href="/style.css"></noscript>')
+    })
+
+    it('uses the "swap-low" preload strategy correctly', () => {
+      const { process } = makeProcessor({ preload: 'swap-low' })
+      const result = process(BASIC_HTML)
+      expect(result).toContain(`<link rel="alternate stylesheet" href="/style.css" title="styles" onload="this.title='';this.rel='stylesheet'">`)
+      expect(result).toContain('<noscript><link rel="stylesheet" href="/style.css"></noscript>')
+    })
+
+    it('uses the "js" preload strategy correctly', () => {
+      const { process } = makeProcessor({ preload: 'js' })
+      const result = process(BASIC_HTML)
+      expect(result).toContain('<link rel="preload" href="/style.css" as="style">')
+      expect(result).toContain(`<script data-href="/style.css" data-media="all">function $loadcss(u,m,l){(l=document.createElement('link')).rel='stylesheet';l.href=u;document.head.appendChild(l)}$loadcss(document.currentScript.dataset.href,document.currentScript.dataset.media)</script>`)
+      // classic ordering: link, noscript, script
+      expect(result).toMatch(/<link rel="preload"[^>]*><noscript>[\s\S]*?<\/noscript><script/)
+    })
+
+    it('uses the "js-lazy" preload strategy correctly', () => {
+      const { process } = makeProcessor({ preload: 'js-lazy' })
+      const result = process(BASIC_HTML)
+      expect(result).toContain(`l.media='print';l.onload=function(){l.media=m};l.href=u`)
+      expect(result).toContain('data-media="all"')
+    })
+
+    it('respects noscriptFallback: false', () => {
+      const { process } = makeProcessor({ preload: 'swap', noscriptFallback: false })
+      const result = process(BASIC_HTML)
+      expect(result).toContain('onload=')
+      expect(result).not.toContain('<noscript>')
+    })
+
+    it('preserves a valid media attribute and sanitizes an unsafe one', () => {
+      const html = BASIC_HTML.replace('<link rel="stylesheet" href="/style.css">', '<link rel="stylesheet" href="/style.css" media="(min-width: 40em)">')
+      const { process } = makeProcessor({ preload: 'media' })
+      expect(process(html)).toContain(`onload="this.media='(min-width: 40em)'"`)
+
+      const unsafe = BASIC_HTML.replace('<link rel="stylesheet" href="/style.css">', `<link rel="stylesheet" href="/style.css" media="'&quot;><script>alert(1)</script>">`)
+      expect(process(unsafe)).toContain(`onload="this.media='all'"`)
+    })
+
+    it('removes id attributes from cloned links', () => {
+      const html = BASIC_HTML.replace('<link rel="stylesheet" href="/style.css">', '<link id="main-css" rel="stylesheet" href="/style.css">')
+      const { process } = makeProcessor()
+      const result = process(html)
+      expect(result).toContain('<link id="main-css" rel="preload" href="/style.css" as="style">')
+      expect(result).toContain('<link rel="stylesheet" href="/style.css"></body>')
+      expect(result.match(/id="main-css"/g)).toHaveLength(1)
+    })
+
+    it('emits font preload links', () => {
+      const css = trim`
+        h1 { font-family: MyFont; }
+        @font-face { font-family: MyFont; src: url(/fonts/my.woff2); }
+      `
+      const { process } = createProcessor([compileSheet(css, { href: 'style.css' })], { fonts: true })
+      const result = process(BASIC_HTML)
+      expect(result).toContain('<link rel="preload" as="font" crossorigin="anonymous" href="/fonts/my.woff2">')
+    })
+
+    it('leaves html untouched when no sheets match', () => {
+      const { process } = createProcessor([compileSheet('h1{color:blue}', { href: 'other.css' })])
+      expect(process(BASIC_HTML)).toBe(BASIC_HTML)
+    })
+
+    it('caches rendered critical css by document token fingerprint', () => {
+      let rulesAccesses = 0
+      const compiled = compileSheet('h1 { color: blue; } .unused { color: red; }', { href: 'style.css' })
+      const sheet = Object.create(compiled, {
+        rules: {
+          get() {
+            rulesAccesses++
+            return compiled.rules
+          },
+        },
+      }) as typeof compiled
+
+      const { process } = createProcessor([sheet])
+      const baseline = rulesAccesses
+
+      const first = process(BASIC_HTML)
+      expect(rulesAccesses).toBeGreaterThan(baseline)
+      const afterFirst = rulesAccesses
+
+      expect(process(BASIC_HTML)).toBe(first)
+      expect(rulesAccesses).toBe(afterFirst)
+
+      const otherHtml = BASIC_HTML.replace('<h1>', '<h1 class="extra">')
+      process(otherHtml)
+      expect(rulesAccesses).toBeGreaterThan(afterFirst)
+    })
+
+    it('supports disabling the cache and bounding its size', () => {
+      let rulesAccesses = 0
+      const compiled = compileSheet('h1 { color: blue; }', { href: 'style.css' })
+      const sheet = Object.create(compiled, {
+        rules: {
+          get() {
+            rulesAccesses++
+            return compiled.rules
+          },
+        },
+      }) as typeof compiled
+
+      const uncached = createProcessor([sheet], { cache: false })
+      const baseline = rulesAccesses
+      uncached.process(BASIC_HTML)
+      const afterFirst = rulesAccesses
+      uncached.process(BASIC_HTML)
+      expect(rulesAccesses).toBeGreaterThan(afterFirst)
+      expect(afterFirst).toBeGreaterThan(baseline)
+
+      const bounded = createProcessor([sheet], { cache: { maxSize: 1 } })
+      const otherHtml = BASIC_HTML.replace('<h1>', '<h1 class="extra">')
+      bounded.process(BASIC_HTML)
+      bounded.process(otherHtml)
+      const beforeEvicted = rulesAccesses
+      // BASIC_HTML's entry was evicted by otherHtml, so this re-renders
+      bounded.process(BASIC_HTML)
+      expect(rulesAccesses).toBeGreaterThan(beforeEvicted)
+    })
+
+    it('produces a JSON-serializable plan', () => {
+      const css = fs.readFileSync(path.join(fixtureDir, 'styles.css'), 'utf-8')
+      const sheet = compileSheet(css, { href: 'styles.css' })
+      const roundTripped = JSON.parse(JSON.stringify(sheet))
+      const html = fs.readFileSync(path.join(fixtureDir, 'index.html'), 'utf-8')
+      expect(renderCriticalCss(roundTripped, scanHtml(html), {}).css).toBe(renderCriticalCss(sheet, scanHtml(html), {}).css)
+    })
+  })
+})

--- a/packages/beasties/test/plan.test.ts
+++ b/packages/beasties/test/plan.test.ts
@@ -1,0 +1,165 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+import { compileSheet, encodePlan } from '../src/compiler'
+import { collectPrograms, createProcessor, decodePlan, renderCriticalCss, scanHtml } from '../src/runtime'
+
+const fixtureDir = fileURLToPath(new URL('./src', import.meta.url))
+
+function roundTrip(sheet: ReturnType<typeof compileSheet>) {
+  return decodePlan(JSON.parse(JSON.stringify(encodePlan(sheet))))
+}
+
+function critical(sheet: ReturnType<typeof compileSheet>, html: string, options = {}) {
+  return renderCriticalCss(sheet, scanHtml(html, collectPrograms([sheet])), options).css
+}
+
+const HTML = `
+<html><head><link rel="stylesheet" href="/style.css"></head><body>
+  <div id="app" class="card md:flex" data-theme="dark" lang="en-GB">
+    <h1 class="title big">hi</h1>
+    <p class="lead">text</p>
+    <span class="a b">x</span>
+  </div>
+  <footer><span class="note">n</span></footer>
+</body></html>`
+
+const CASES: Record<string, string> = {
+  'simple selectors': 'h1 { color: blue } .unused { color: red } #app { display: flex } div { margin: 0 }',
+  'compound and attribute selectors': '.a.b { color: red } [data-theme="dark"] { color: blue } [lang|="en"] { color: teal } h1.title.big { color: green } [data-missing] { color: pink }',
+  'combinators': '#app .lead { color: red } #app > .title { color: blue } .title + .lead { color: teal } .lead ~ .a { color: olive } .note .a { color: gray }',
+  'escaped class names': '.md\\:flex { display: flex } .lg\\:hidden { display: none } .md\\:flex.card { color: red }',
+  'media and supports': '@media (min-width: 40em) { .title { font-size: 3rem } .unused { color: red } } @supports (display: grid) { #app { display: grid } }',
+  'layers': '@layer a, b; @layer base { .unused { color: red } } @layer components { h1 { color: blue } }',
+  'keyframes and fonts': '.lead { animation: fade 1s; font-family: MyFont } @keyframes fade { from { opacity: 0 } } @keyframes spin { to { opacity: 1 } } @font-face { font-family: MyFont; src: url(/f.woff2) } @font-face { font-family: Unused; src: url(/u.woff2) }',
+  'comment markers': '/* beasties:exclude */ h1 { color: blue } /* beasties:include */ .never { color: red } /* beasties:include start */ .also-never { color: teal } /* beasties:include end */',
+  'nested rules': '.card { color: red; & .lead { color: blue } } .unused { color: red; & .lead { color: teal } }',
+  'statement at-rules': '@charset "utf-8"; @import url("other.css"); h1 { color: blue }',
+  'pseudo classes': 'h1:hover { color: red } .lead::first-line { font-weight: bold } .missing:focus { outline: 0 } div:is(:hover, .card) { color: teal }',
+  'repeated bodies': `${Array.from({ length: 20 }, (_, i) => `.rep-${i} { margin: ${i % 3}px; padding: 2px }`).join('\n')}\n.card { margin: 1px; padding: 2px }`,
+}
+
+describe('compact plan format', () => {
+  describe('round-trips without changing output', () => {
+    for (const [label, css] of Object.entries(CASES)) {
+      it(label, () => {
+        const sheet = compileSheet(css, { href: 'style.css' })
+        const options = { fonts: true, keyframes: 'critical' as const }
+        expect(critical(roundTrip(sheet), HTML, options)).toBe(critical(sheet, HTML, options))
+      })
+    }
+
+    it('every fixture stylesheet', () => {
+      const html = fs.readFileSync(path.join(fixtureDir, 'index.html'), 'utf-8')
+      for (const file of ['styles.css', 'styles2.css', 'colors.css', 'prune-source.css', 'large.css']) {
+        const sheet = compileSheet(fs.readFileSync(path.join(fixtureDir, file), 'utf-8'), { href: file })
+        expect(critical(roundTrip(sheet), html), file).toBe(critical(sheet, html))
+      }
+    })
+
+    it('preserves allowRules and non-exact compilation', () => {
+      const css = '.always { color: red } .a .b { color: blue }'
+      for (const compileOptions of [{ allowRules: ['.always', /^\.a/] }, { exact: false }]) {
+        const sheet = compileSheet(css, { href: 'style.css', ...compileOptions })
+        expect(critical(roundTrip(sheet), HTML)).toBe(critical(sheet, HTML))
+      }
+    })
+  })
+
+  describe('encoding', () => {
+    function encodedRules(css: string) {
+      return encodePlan(compileSheet(css, { href: 'style.css' }))[5]
+    }
+
+    it('stores selector-derivable conditions as markers', () => {
+      const [byClass, byId, byTag] = encodedRules('.foo { color: red } #bar { color: red } DIV { color: red }')
+      // [flags, selector, body, match]
+      expect(byClass![3]).toEqual([1])
+      expect(byId![3]).toEqual([2])
+      expect(byTag![3]).toEqual([3])
+    })
+
+    it('does not use markers when the selector text differs from the parsed value', () => {
+      const [escaped] = encodedRules('.md\\:flex { display: flex }')
+      expect(escaped![3]).not.toEqual([1])
+
+      const sheet = compileSheet('.md\\:flex { display: flex }', { href: 'style.css' })
+      const decoded = roundTrip(sheet)
+      expect(decoded.rules[0]!.match).toEqual([{ classes: ['md:flex'] }])
+      expect(critical(decoded, '<html><body><div class="md:flex"></div></body></html>')).toBe('.md\\:flex{display:flex}')
+    })
+
+    it('drops token fields when a structural program decides the match', () => {
+      const sheet = compileSheet('.a > .b { color: red }', { href: 'style.css' })
+      const original = sheet.rules[0]!.match![0]
+      expect(original).toMatchObject({ classes: ['a', 'b'], program: expect.any(Object) })
+
+      const decoded = roundTrip(sheet).rules[0]!.match![0]
+      expect(decoded).toEqual({ program: { combinators: ['>'], compounds: [{ classes: ['a'] }, { classes: ['b'] }] } })
+    })
+
+    it('pools strings used more than once and inlines unique ones', () => {
+      const plan = encodePlan(compileSheet(CASES['repeated bodies']!, { href: 'style.css' }))
+      const pool = plan[3]
+      expect(pool).toContain('{margin:1px;padding:2px}')
+      expect(pool.some(entry => entry.includes('rep-0'))).toBe(false)
+
+      const bodies = plan[5].map(rule => rule[2])
+      expect(bodies.filter(body => typeof body === 'number').length).toBeGreaterThan(15)
+    })
+
+    it('shares repeated at-rule wrappers', () => {
+      const css = '@media (min-width: 40em) { h1 { color: red } .lead { color: blue } } @media (min-width: 40em) { .title { color: teal } }'
+      const plan = encodePlan(compileSheet(css, { href: 'style.css' }))
+      expect(plan[4]).toHaveLength(1)
+      for (const rule of plan[5]) {
+        expect(rule.at(-1)).toBe(0)
+      }
+    })
+
+    it('drops build-time warnings', () => {
+      const sheet = compileSheet('h1 { color: blue }', { href: 'style.css' })
+      sheet.warnings.push('some selector -> failed')
+      expect(JSON.stringify(encodePlan(sheet))).not.toContain('failed')
+      expect(roundTrip(sheet).warnings).toEqual([])
+    })
+
+    it('keeps href and source size', () => {
+      const sheet = compileSheet('h1 { color: blue }', { href: '_nuxt/entry.abc.css' })
+      const decoded = roundTrip(sheet)
+      expect(decoded.href).toBe('_nuxt/entry.abc.css')
+      expect(decoded.size).toBe(sheet.size)
+
+      const anonymous = roundTrip(compileSheet('h1 { color: blue }'))
+      expect(anonymous.href).toBeUndefined()
+    })
+
+    it('is smaller than the equivalent CompiledSheet json', () => {
+      for (const css of Object.values(CASES)) {
+        const sheet = compileSheet(css, { href: 'style.css' })
+        const encoded = JSON.stringify(encodePlan(sheet)).length
+        expect(encoded).toBeLessThan(JSON.stringify(sheet).length)
+      }
+    })
+  })
+
+  describe('createProcessor', () => {
+    it('accepts compact plans directly', () => {
+      const css = 'h1 { color: blue } .unused { color: red } .a > .b { color: teal }'
+      const sheet = compileSheet(css, { href: 'style.css' })
+      const fromSheet = createProcessor([sheet]).process(HTML)
+      const fromPlan = createProcessor([JSON.parse(JSON.stringify(encodePlan(sheet)))]).process(HTML)
+      expect(fromPlan).toBe(fromSheet)
+    })
+
+    it('accepts a mix of compact plans and compiled sheets', () => {
+      const a = compileSheet('h1 { color: blue }', { href: 'a.css' })
+      const b = compileSheet('.lead { color: red }', { href: 'b.css' })
+      const html = HTML.replace('<link rel="stylesheet" href="/style.css">', '<link rel="stylesheet" href="/a.css"><link rel="stylesheet" href="/b.css">')
+      expect(createProcessor([encodePlan(a), b]).extract(html).css)
+        .toBe(createProcessor([a, b]).extract(html).css)
+    })
+  })
+})

--- a/packages/beasties/tsdown.config.mts
+++ b/packages/beasties/tsdown.config.mts
@@ -1,8 +1,15 @@
 import { defineConfig } from 'tsdown'
 
-export default defineConfig({
-  entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
-  dts: false,
-  copy: [{ from: 'src/index.d.ts', to: 'dist' }],
-}) as ReturnType<typeof defineConfig>
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm', 'cjs'],
+    dts: false,
+    copy: [{ from: 'src/index.d.ts', to: 'dist' }],
+  },
+  {
+    entry: ['src/compiler.ts', 'src/runtime.ts'],
+    format: ['esm'],
+    dts: true,
+  },
+]) as ReturnType<typeof defineConfig>


### PR DESCRIPTION
thinking about using beasties at runtime (for example, https://github.com/nuxt/nuxt/issues/35250), there are two big blockers:

1. runtime dependencies - with its deps, [beasties is 2.5 MB](https://npmx.dev/package/beasties) of which ~1.8 MB would end up in the bundle
2. repeated work - every response re-parsed into DOM and stylesheets parsed into postcss, etc...

BUT ... after a build the css is often static, so we can process it _in advance_.

this PR adds two subpath exports, `beasties/compiler` (build time, keeps postcss and css-what) and `beasties/runtime` (per request, no dependencies)

| | classic `process()` | `beasties/runtime` |
| --- | --- | --- |
| 13 kB css, 21 kB html | 3.0ms | 0.4ms |
| 413 kB css, 21 kB html | 36.1ms | 1.2ms |
| runtime dependencies | 9 (~1.8 MB unpacked) | none (~27 kB) |

### 🔬how it works

1. **the compiler turns a stylesheet into a 'plan'**

   `compileSheet(css, { href })`. plans are json-serialisable, and have their rules pre-minified, selectors normalised, comment markers and `allowRules` resolved, `url()` values rebased and font and keyframe dependencies extracted. 

2. **the processor makes a single pass over the html at runtime**

   `createProcessor(plans).process(html)`. tags, classes, ids and attributes are collected, and then the critical css is spliced in as a string instead of round-tripping a dom.

   without a dom, selectors obviously don't apply with 100% accuracy. simple selectors (like one class, id, tag, or attribute presence) are decided simply by presence in those token sets. anything else, like combinators, compound selectors like `.a.b`, and attribute values, compile to a small match program that runs during the same scan and uses the open-element stack for ancestor and sibling context.

   in all my testing, this ends up with the same result but your mileage may vary. you can instead set `exact: false` at compile time which falls back to token presence only, which over-inlines combinator selectors but is cheaper (and safer).

### ⚙️ configuring beasties

options are split roughly along the same line:

| option | where |
| --- | --- |
| `allowRules`, `safeParser`, `exact`, comment markers | build-time |
| `preload` (all strategies), `noscriptFallback`, `keyframes`, `fonts`, `inlineFonts`, `preloadFonts`, `inlineThreshold`, `minimumExternalSize`, `cache` | runtime |
| `path`, `publicPath`, `external`, `remote`, `additionalStylesheets` | configurable |
| `pruneSource` | ❌ |
| `reduceInlineStyles` | ❌ |

> [!NOTE]
> `minimumExternalSize` is measured not against the stylesheet but against the rules that weren't inlined instead. it and `inlineThreshold` still both inline the stylesheet in full and remove its `<link>` entirely.

### 🔥 performance

because plans will be embedded in a server bundle, they're designed to be stored compactly, using positional arrays, a string pool, and conditions rederived from their selector if it round-trips exactly... this leads to reasonable results compared to the source stylesheets:

| stylesheet | encoded plan |
| --- | --- |
| 13 kB fixture | 15 kB (1.15x) |
| 413 kB utility-scale | 198 kB (0.48x) |

utility css pools even ends up smaller than the css it describes 🎉
decoding costs about 9ms once at startup for a 300 kB plan.

finally, we also cache critical css is per document shape, keyed on a fingerprint of the scanned tokens. enable this only for large stylesheets, as (with smaller stylesheets) the scan is the expensive piece...


resolves https://github.com/danielroe/beasties/issues/220