### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/beasties/src/dom.ts
+++ b/packages/beasties/src/dom.ts
@@ -121,13 +121,12 @@ declare module 'domhandler' {
  * @private
  */
 let extended = false
-function extendElement(element: typeof Element.prototype) {
-  if (extended) {
+export function extendElement(element: typeof Element.prototype): void {
+  if (element === Element.prototype && extended) {
     return
   }
-  extended = true
 
-  Object.defineProperties(element, {
+  const descriptors: PropertyDescriptorMap & ThisType<typeof Element.prototype> = {
     nodeName: {
       get() {
         return this.tagName.toUpperCase()
@@ -244,7 +243,17 @@ function extendElement(element: typeof Element.prototype) {
         return selectAll(sel, this)
       },
     },
-  })
+  }
+
+  for (const property of Object.keys(descriptors)) {
+    if (Object.hasOwn(element, property)) {
+      delete descriptors[property]
+    }
+  }
+  Object.defineProperties(element, descriptors)
+  if (element === Element.prototype) {
+    extended = true
+  }
 }
 
 export interface HTMLDocument extends ParsedDocument {

--- a/packages/beasties/test/dom.test.ts
+++ b/packages/beasties/test/dom.test.ts
@@ -1,7 +1,19 @@
+import type { Element } from 'domhandler'
 import { describe, expect, it } from 'vitest'
-import { createDocument } from '../src/dom'
+import { createDocument, extendElement } from '../src/dom'
 
 describe('dom', () => {
+  it('preserves a nodeName property provided by the DOM implementation', () => {
+    const element = {}
+    Object.defineProperty(element, 'nodeName', {
+      configurable: false,
+      value: 'provided-node-name',
+    })
+
+    expect(() => extendElement(element as unknown as Element)).not.toThrow()
+    expect(element).toHaveProperty('nodeName', 'provided-node-name')
+  })
+
   describe('exists() selector cache', () => {
     it('falls through to DOM query when selector has a complex group', () => {
       const doc = createDocument(`


### PR DESCRIPTION
Fixes #263.

Avoid redefining element properties already supplied by the DOM implementation. This prevents `nodeName` descriptor collisions while retaining Beasties shims where the parser does not provide them.

Tests: `pnpm vitest run packages/beasties/test/dom.test.ts`, `pnpm test:types`.