### PR TITLE
fix(beasties): tolerate duplicate domhandler and beasties copies

### DIFF
--- a/packages/beasties/src/dom.ts
+++ b/packages/beasties/src/dom.ts
@@ -17,12 +17,14 @@
 import type { AttributeSelector } from 'css-what'
 
 import type { ChildNode, Node, NodeWithChildren } from 'domhandler'
+import type { Logger } from './util'
 
 import { selectAll, selectOne } from 'css-select'
 import { parse as selectorParser } from 'css-what'
 import render from 'dom-serializer'
 import { Element, Text } from 'domhandler'
 import { DomUtils, parseDocument } from 'htmlparser2'
+import { version } from '../package.json'
 
 type ParsedDocument = ReturnType<typeof parseDocument>
 
@@ -57,13 +59,19 @@ function buildCache(container: Node) {
  * The DOM implementation is an htmlparser2 DOM enhanced with basic DOM mutation methods.
  * @param html   HTML to parse into a Document instance
  */
-export function createDocument(html: string): HTMLDocument {
+export function createDocument(html: string, logger?: Logger): HTMLDocument {
   const document = parseDocument(html, { decodeEntities: false })
 
   extendDocument(document)
 
-  // Extend Element.prototype with DOM manipulation methods.
-  extendElement(Element.prototype)
+  // Extend Element.prototype with DOM manipulation methods. `htmlparser2` may
+  // resolve a different copy of `domhandler` than we do, in which case parsed
+  // nodes do not inherit from the `Element` imported here.
+  const parsedPrototype = Object.getPrototypeOf(document.children.find(child => child.type === 'tag') ?? Element.prototype)
+  extendElement(parsedPrototype, logger)
+  if (parsedPrototype !== Element.prototype) {
+    extendElement(Element.prototype, logger)
+  }
 
   // Beasties containers are the viewport to evaluate critical CSS.
   let beastiesContainers: (Node | HTMLDocument)[] = document.querySelectorAll('[data-beasties-container]') as Node[]
@@ -120,12 +128,24 @@ declare module 'domhandler' {
  * Methods and descriptors to mix into Element.prototype
  * @private
  */
-let extended = false
-function extendElement(element: typeof Element.prototype) {
-  if (extended) {
+const extendedMarker = Symbol.for('beasties.element-extended')
+
+function extendElement(element: typeof Element.prototype, logger?: Logger) {
+  // `Element.prototype` is shared with any other copy of beasties that resolves
+  // the same `domhandler`, and the descriptors below are non-configurable, so a
+  // second copy must not reapply them.
+  const appliedVersion = (element as unknown as Record<symbol, unknown>)[extendedMarker]
+    ?? (Object.hasOwn(element, 'nodeName') ? 'an older version' : undefined)
+
+  if (typeof appliedVersion === 'string') {
+    if (appliedVersion !== version) {
+      logger?.warn?.(
+        `Multiple versions of beasties are patching the same \`domhandler\` instance (${appliedVersion} applied it, ${version} loaded after). `
+        + `Deduplicate beasties to a single version if you see unexpected DOM errors.`,
+      )
+    }
     return
   }
-  extended = true
 
   Object.defineProperties(element, {
     nodeName: {
@@ -245,6 +265,8 @@ function extendElement(element: typeof Element.prototype) {
       },
     },
   })
+
+  Object.defineProperty(element, extendedMarker, { value: version, configurable: true })
 }
 
 export interface HTMLDocument extends ParsedDocument {

--- a/packages/beasties/src/index.ts
+++ b/packages/beasties/src/index.ts
@@ -113,7 +113,7 @@ export default class Beasties {
     const start = Date.now()
 
     // Parse the generated HTML in a DOM we can mutate
-    const document = createDocument(html)
+    const document = createDocument(html, this.logger)
 
     if (this.options.additionalStylesheets.length > 0) {
       await this.embedAdditionalStylesheet(document)

--- a/packages/beasties/test/dom-foreign-domhandler.test.ts
+++ b/packages/beasties/test/dom-foreign-domhandler.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// deliberately no static import of `../src/dom`: patching `Element.prototype`
+// is global, so this file must only ever load the mocked copy
+describe('dom', () => {
+  describe('a domhandler copy the parser does not share', () => {
+    const HTML = '<html><body><div class="hero">text</div></body></html>'
+
+    /** load a copy of src/dom whose `Element` is not the one htmlparser2 constructs nodes from */
+    async function loadWithForeignDomhandler() {
+      const domhandler = await import('domhandler')
+
+      vi.resetModules()
+      vi.doMock('domhandler', () => ({ ...domhandler, Element: class Element extends domhandler.Element {} }))
+      const { createDocument: createDocumentWithForeignElement } = await import('../src/dom')
+      vi.doUnmock('domhandler')
+      return createDocumentWithForeignElement
+    }
+
+    it('patches the prototype the parser actually produced', async () => {
+      const createDocumentWithForeignElement = await loadWithForeignDomhandler()
+
+      const doc = createDocumentWithForeignElement(HTML)
+
+      expect(doc.documentElement!.getAttribute('data-beasties-container')).toBe('')
+      expect(doc.beastiesContainers[0]!.exists('.hero')).toBe(true)
+    })
+
+    it('still patches its own Element so createElement() is usable', async () => {
+      const createDocumentWithForeignElement = await loadWithForeignDomhandler()
+
+      const doc = createDocumentWithForeignElement(HTML)
+      const el = doc.createElement('style')
+      el.setAttribute('media', 'print')
+      doc.body.appendChild(el)
+
+      expect(doc.body.querySelector('style')!.getAttribute('media')).toBe('print')
+    })
+  })
+})

--- a/packages/beasties/test/dom-legacy-copy.test.ts
+++ b/packages/beasties/test/dom-legacy-copy.test.ts
@@ -1,0 +1,31 @@
+import { Element } from 'domhandler'
+import { describe, expect, it, vi } from 'vitest'
+
+// deliberately no static import of `../src/dom`: this file needs an
+// `Element.prototype` that is fully patched but carries no version marker
+describe('dom', () => {
+  describe('a pre-marker copy that patched first', () => {
+    const HTML = '<html><body><div class="hero">text</div></body></html>'
+
+    it('reuses its descriptors instead of throwing', async () => {
+      const domhandler = await import('domhandler')
+      const { createDocument } = await import('../src/dom')
+      createDocument(HTML)
+
+      // versions before the marker existed left only their descriptors behind
+      delete (Element.prototype as unknown as Record<symbol, unknown>)[Symbol.for('beasties.element-extended')]
+
+      vi.resetModules()
+      vi.doMock('domhandler', () => domhandler)
+      const { createDocument: createDocumentAgain } = await import('../src/dom')
+      vi.doUnmock('domhandler')
+
+      const logger = { warn: vi.fn() }
+      const doc = createDocumentAgain(HTML, logger)
+
+      expect(doc.beastiesContainers[0]!.exists('.hero')).toBe(true)
+      expect(logger.warn).toHaveBeenCalledOnce()
+      expect(logger.warn.mock.calls[0]![0]).toContain('an older version')
+    })
+  })
+})

--- a/packages/beasties/test/dom.test.ts
+++ b/packages/beasties/test/dom.test.ts
@@ -1,7 +1,49 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createDocument } from '../src/dom'
 
 describe('dom', () => {
+  describe('duplicate copies sharing one domhandler', () => {
+    const HTML = '<html><body><div class="hero">text</div></body></html>'
+
+    /** load a second copy of src/dom that resolves the already-loaded domhandler */
+    async function loadSecondCopy(version?: string) {
+      const domhandler = await import('domhandler')
+      createDocument(HTML)
+
+      vi.resetModules()
+      vi.doMock('domhandler', () => domhandler)
+      if (version) {
+        const pkg = await import('../package.json')
+        vi.doMock('../package.json', () => ({ ...pkg, version }))
+      }
+      const { createDocument: createDocumentAgain } = await import('../src/dom')
+      vi.doUnmock('domhandler')
+      vi.doUnmock('../package.json')
+      return createDocumentAgain
+    }
+
+    it('reuses the existing patch instead of throwing', async () => {
+      const createDocumentAgain = await loadSecondCopy()
+      const logger = { warn: vi.fn() }
+
+      const doc = createDocumentAgain(HTML, logger)
+
+      expect(doc.beastiesContainers[0]!.exists('.hero')).toBe(true)
+      expect(logger.warn).not.toHaveBeenCalled()
+    })
+
+    it('warns when the copies are different versions', async () => {
+      const createDocumentAgain = await loadSecondCopy('99.0.0')
+      const logger = { warn: vi.fn() }
+
+      createDocumentAgain(HTML, logger)
+
+      expect(logger.warn).toHaveBeenCalledOnce()
+      expect(logger.warn.mock.calls[0]![0]).toContain('Multiple versions of beasties')
+      expect(logger.warn.mock.calls[0]![0]).toContain('99.0.0')
+    })
+  })
+
   describe('exists() selector cache', () => {
     it('falls through to DOM query when selector has a complex group', () => {
       const doc = createDocument(`


### PR DESCRIPTION
resolves #140 
resolves #263

two issues with a very similar cause - global patching of element prototypes

this adds a version marker and logs rather than failing outright. in future we may refactor this to avoid patching at all.