### PR TITLE
fix(beasties): support `data-beasties-skip` + stylesheet warnings in fast path

### DIFF
--- a/packages/beasties/src/runtime.ts
+++ b/packages/beasties/src/runtime.ts
@@ -792,6 +792,11 @@ export interface ProcessorOptions extends RuntimeOptions {
    * `<link>` _(default: `0`, disabled)_
    */
   minimumExternalSize?: number
+  /**
+   * Receives warnings, e.g. for `<link rel="stylesheet">` tags with no
+   * matching compiled sheet _(default: no warnings are emitted)_
+   */
+  logger?: { warn?: (message: string) => void }
 }
 
 const DEFAULT_CACHE_SIZE = 100
@@ -817,6 +822,7 @@ function fingerprintTokens(tokens: DocumentTokens): string {
   return parts.join(' ')
 }
 
+const CSS_HREF_RE = /\.css(?:[?#]|$)/i
 const LINK_TAG_RE = /<link\b(?:[^>"']|"[^"]*"|'[^']*')*>/gi
 const REL_STYLESHEET_RE = /\brel\s*=\s*(?:"stylesheet"|'stylesheet'|stylesheet(?=[\s>]))/i
 // conservative allowlist so a media attribute can be re-emitted into onload
@@ -1011,12 +1017,32 @@ export function createProcessor(plans: Array<CompiledSheet | CompactPlan>, optio
     return result
   }
 
+  function skippedSheets(html: string): Set<CompiledSheet> | undefined {
+    let skipped: Set<CompiledSheet> | undefined
+    for (const match of html.matchAll(LINK_TAG_RE)) {
+      const tag = match[0]
+      if (!REL_STYLESHEET_RE.test(tag) || getAttr(tag, 'data-beasties-skip') === null) {
+        continue
+      }
+      const href = getAttr(tag, 'href')
+      const sheet = href ? sheetForHref(sheets, href) : undefined
+      if (sheet) {
+        (skipped ??= new Set()).add(sheet)
+      }
+    }
+    return skipped
+  }
+
   function extract(html: string): CriticalResult {
     const tokens = scanHtml(html, programs)
     const key = cache ? fingerprintTokens(tokens) : undefined
+    const skipped = skippedSheets(html)
     const css: string[] = []
     const fontPreloads: string[] = []
     for (const sheet of sheets) {
+      if (skipped?.has(sheet)) {
+        continue
+      }
       const result = renderSheet(sheet, tokens, key)
       css.push(inlineInFull(sheet, result) ? fullCss(sheet) : result.css)
       fontPreloads.push(...result.fontPreloads)
@@ -1041,12 +1067,18 @@ export function createProcessor(plans: Array<CompiledSheet | CompactPlan>, optio
       if (!REL_STYLESHEET_RE.test(tag)) {
         continue
       }
+      if (getAttr(tag, 'data-beasties-skip') !== null) {
+        continue
+      }
       const href = getAttr(tag, 'href')
       if (!href) {
         continue
       }
       const sheet = sheetForHref(sheets, href)
       if (!sheet) {
+        if (CSS_HREF_RE.test(href)) {
+          options.logger?.warn?.(`Unable to locate stylesheet: ${href}`)
+        }
         continue
       }
 

--- a/packages/beasties/test/compiled.test.ts
+++ b/packages/beasties/test/compiled.test.ts
@@ -427,6 +427,53 @@ describe('compiled beasties (compiler + runtime)', () => {
     })
   })
 
+  describe('data-beasties-skip', () => {
+    const assets: Record<string, string> = {
+      '/styles.css': 'h1 { color: blue; }',
+      '/theme.css': 'body { background: red; }',
+    }
+
+    const HTML = trim`
+      <html>
+        <head>
+          <link rel="stylesheet" href="/styles.css">
+          <link rel="stylesheet" href="/theme.css" data-beasties-skip>
+        </head>
+        <body><h1>Hello</h1></body>
+      </html>
+    `
+
+    function classic(options: ConstructorParameters<typeof Beasties>[0] = {}) {
+      const beasties = new Beasties({ reduceInlineStyles: false, path: '/', logLevel: 'silent', ...options })
+      beasties.readFile = filename => assets[filename.replace(/^\w:/, '').replace(/\\/g, '/')]!
+      return beasties.process(HTML)
+    }
+
+    function compiled(options: Parameters<typeof createProcessor>[1] = {}) {
+      const sheets = Object.entries(assets).map(([href, css]) => compileSheet(css, { href }))
+      return createProcessor(sheets, options).process(HTML)
+    }
+
+    for (const preload of [false, 'media', 'swap', 'js', 'body'] as const) {
+      it(`leaves the skipped link untouched on both paths with preload: ${preload}`, async () => {
+        for (const result of [await classic({ preload }), compiled({ preload })]) {
+          expect(result).toContain('<link rel="stylesheet" href="/theme.css" data-beasties-skip>')
+          expect(result).not.toMatch(/theme\.css[^>]*onload/)
+          expect(result).not.toMatch(/theme\.css[^>]*rel="preload"/)
+          expect(result).not.toMatch(/noscript[^>]*theme/)
+          expect(result).not.toContain('background:red')
+          expect(result).toContain('color:blue')
+        }
+      })
+    }
+
+    it('excludes the skipped stylesheet from extract()', () => {
+      const sheets = Object.entries(assets).map(([href, css]) => compileSheet(css, { href }))
+      const { extract } = createProcessor(sheets)
+      expect(extract(HTML).css).toBe('h1{color:blue}')
+    })
+  })
+
   describe('whole-sheet inlining', () => {
     const CSS = trim`
       h1 { color: blue; }
@@ -745,6 +792,22 @@ describe('compiled beasties (compiler + runtime)', () => {
       // BASIC_HTML's entry was evicted by otherHtml, so this re-renders
       bounded.process(BASIC_HTML)
       expect(rulesAccesses).toBeGreaterThan(beforeEvicted)
+    })
+
+    it('warns when a stylesheet link has no matching compiled sheet', () => {
+      const warnings: string[] = []
+      const { process } = makeProcessor({ preload: false, logger: { warn: message => void warnings.push(message) } })
+      process(trim`
+        <html>
+          <head>
+            <link rel="stylesheet" href="/style.css">
+            <link rel="stylesheet" href="/missing.css">
+            <link rel="stylesheet" href="/not-a-sheet">
+          </head>
+          <body><h1>Hello</h1></body>
+        </html>
+      `)
+      expect(warnings).toEqual(['Unable to locate stylesheet: /missing.css'])
     })
 
     it('produces a JSON-serializable plan', () => {


### PR DESCRIPTION
`data-beasties-skip` was only honoured on the PostCSS path, so it stopped working with compiler/runtime

now, both `process()` and `extract()` now skip those links + there's a `Unable to locate stylesheet` warning in the fast path
