### PR TITLE
feat(beasties): accept `critters:` directives + warn on unknown ones

### DIFF
--- a/packages/beasties/README.md
+++ b/packages/beasties/README.md
@@ -200,6 +200,10 @@ Including/Excluding multiple rules by adding start and end markers
 /* beasties:include end */
 ```
 
+The supported directives are `beasties:include`, `beasties:exclude`, `beasties:include start`, `beasties:include end`, `beasties:exclude start` and `beasties:exclude end`.
+
+The `critters:` prefix (from the project beasties was forked from) is still accepted as a deprecated alias and logs a warning. Comments which look like a directive but aren't recognised, such as `/* beasties:inclde */` or `/* critter:include */`, also log a warning rather than being silently ignored.
+
 ### Programmatically including rules with allowRules
 
 In addition to comment-based inclusion, you can use the `allowRules` option to programmatically include specific selectors or patterns in the critical CSS, regardless of whether they match elements in the document. This is useful for cases where you know certain styles should always be included.

--- a/packages/beasties/src/compiler.ts
+++ b/packages/beasties/src/compiler.ts
@@ -11,14 +11,13 @@ import type { Selector } from 'css-what'
 import type { AtRule, Container, Rule } from 'postcss'
 import { parse as parseSelectorAst } from 'css-what'
 import { parseStylesheet, serializeStylesheet } from './css'
+import { CRITTERS_DEPRECATION_WARNING, parseDirective } from './directives'
 import { isAlwaysCriticalSelector, normalizeCssSelector } from './selectors'
 import { resolveCssUrl, rewriteCssUrls } from './urls'
 
 export type { CompactPlan } from './plan'
 export { encodePlan } from './plan-encode'
 
-// eslint-disable-next-line regexp/no-useless-assertions
-const BEASTIES_COMMENT_RE = /^(?<!! )beasties:(.*)/
 const FONT_FAMILY_RE = /\bfont(?:-family)?\b/i
 const WHITESPACE_RE = /\s+/
 // eslint-disable-next-line regexp/no-super-linear-backtracking,regexp/no-misleading-capturing-group
@@ -138,6 +137,7 @@ interface MarkerState {
   excludeNext: boolean
   includeAll: boolean
   excludeAll: boolean
+  warnedCritters: boolean
 }
 
 export function compileSheet(css: string, options: CompileOptions = {}): CompiledSheet {
@@ -158,6 +158,7 @@ export function compileSheet(css: string, options: CompileOptions = {}): Compile
     excludeNext: false,
     includeAll: false,
     excludeAll: false,
+    warnedCritters: false,
   }
 
   walk(ast, [], sheet, state, options, rebase)
@@ -170,8 +171,14 @@ type Rebase = (text: string) => string
 function walk(container: Container, wrap: string[], sheet: CompiledSheet, state: MarkerState, options: CompileOptions, rebase: Rebase) {
   for (const node of container.nodes ?? []) {
     if (node.type === 'comment') {
-      const match = node.text.match(BEASTIES_COMMENT_RE)
-      const command = match && match[1]
+      const { command, deprecated, warning } = parseDirective(node.text)
+      if (warning) {
+        sheet.warnings.push(warning)
+      }
+      if (deprecated && !state.warnedCritters) {
+        state.warnedCritters = true
+        sheet.warnings.push(CRITTERS_DEPRECATION_WARNING)
+      }
       if (command) {
         switch (command) {
           case 'include':

--- a/packages/beasties/src/directives.ts
+++ b/packages/beasties/src/directives.ts
@@ -1,0 +1,64 @@
+/**
+ * Parsing of in-CSS comment directives (`/* beasties:include start *\/` and friends).
+ *
+ * Shared by the runtime path (`index.ts`) and the build-time compiler
+ * (`compiler.ts`) so both accept the same spellings and produce the same
+ * diagnostics.
+ */
+
+type DirectiveCommand
+  = | 'include'
+    | 'exclude'
+    | 'include start'
+    | 'include end'
+    | 'exclude start'
+    | 'exclude end'
+
+const DIRECTIVE_RE = /^(beasties|critters):(.*)$/
+/**
+ * A comment which looks like a directive but uses an unknown namespace, e.g.
+ * `/* critter:include *\/`. Deliberately narrow: a single bare word followed by
+ * `include`/`exclude` and an optional `start`/`end`, and nothing else, so that
+ * license banners, sourcemap comments and ordinary prose never match.
+ */
+const DIRECTIVE_LOOKALIKE_RE = /^([\w-]+):(include|exclude)(?: (start|end))?$/
+
+const COMMANDS = new Set<string>(['include', 'exclude', 'include start', 'include end', 'exclude start', 'exclude end'])
+
+const SUPPORTED_DIRECTIVES = [...COMMANDS].map(command => `beasties:${command}`).join(', ')
+
+export interface DirectiveResult {
+  command?: DirectiveCommand
+  /** Set when a `critters:` prefixed directive was used */
+  deprecated?: boolean
+  /** Set when the comment looked like a directive but could not be understood */
+  warning?: string
+}
+
+/**
+ * Interpret a CSS comment's text as a beasties directive.
+ *
+ * `text` is the comment body with the delimiters removed and whitespace
+ * trimmed, i.e. postcss' `Comment#text`. Comments beginning with `!` (legal
+ * comments preserved by minifiers) are not treated as directives.
+ */
+export function parseDirective(text: string): DirectiveResult {
+  const match = text.match(DIRECTIVE_RE)
+  if (match) {
+    const command = match[2]!.trim()
+    if (COMMANDS.has(command)) {
+      return { command: command as DirectiveCommand, deprecated: match[1] === 'critters' }
+    }
+    return { warning: `Unknown comment directive "${text}". Supported directives are: ${SUPPORTED_DIRECTIVES}.` }
+  }
+
+  const lookalike = text.match(DIRECTIVE_LOOKALIKE_RE)
+  if (lookalike) {
+    const command = lookalike[3] ? `${lookalike[2]} ${lookalike[3]}` : lookalike[2]
+    return { warning: `Ignoring unrecognised comment directive "${text}". Did you mean "beasties:${command}"?` }
+  }
+
+  return {}
+}
+
+export const CRITTERS_DEPRECATION_WARNING: string = 'Found deprecated "critters:" comment directives. Use the "beasties:" prefix instead, for example "/* beasties:include start */".'

--- a/packages/beasties/src/index.ts
+++ b/packages/beasties/src/index.ts
@@ -23,6 +23,7 @@ import { readFile, writeFile } from 'node:fs'
 import path from 'node:path'
 
 import { applyMarkedSelectors, markOnly, parseStylesheet, serializeStylesheet, validateMediaQuery, walkStyleRules, walkStyleRulesWithReverseMirror } from './css'
+import { CRITTERS_DEPRECATION_WARNING, parseDirective } from './directives'
 import { createDocument, serializeDocument } from './dom'
 import { isAlwaysCriticalSelector, normalizeCssSelector } from './selectors'
 import { REMOTE_URL_RE, resolveCssUrl, rewriteCssUrls } from './urls'
@@ -31,8 +32,6 @@ import { createLogger, isSubpath } from './util'
 const LEADING_SLASH_OR_QUERY_RE = /^\/(?!\/)|[?#].*$/g
 const PUBLIC_PATH_RE = /(^\/(?!\/)|\/$)/g
 const FONT_FAMILY_RE = /\bfont(?:-family)?\b/i
-// eslint-disable-next-line regexp/no-useless-assertions
-const BEASTIES_COMMENT_RE = /^(?<!! )beasties:(.*)/
 const LEADING_SLASH_RE = /^\//
 const WHITESPACE_RE = /\s+/
 // eslint-disable-next-line regexp/no-super-linear-backtracking,regexp/no-misleading-capturing-group
@@ -524,6 +523,7 @@ export default class Beasties {
     let includeAll = false
     let excludeNext = false
     let excludeAll = false
+    let warnedCritters = false
 
     const shouldPreloadFonts = options.fonts === true || options.preloadFonts === true
     const shouldInlineFonts = options.fonts !== false && options.inlineFonts === true
@@ -534,10 +534,18 @@ export default class Beasties {
       ast,
       markOnly((rule) => {
         if (rule.type === 'comment') {
-          // we might want to remove a leading ! on comment blocks
-          // beasties can be part of "legal comments" which aren't stripped on build
-          const beastiesComment = rule.text.match(BEASTIES_COMMENT_RE)
-          const command = beastiesComment && beastiesComment[1]
+          // comments starting with `!` are "legal comments" which aren't stripped on build,
+          // so they are not treated as directives
+          const { command, deprecated, warning } = parseDirective(rule.text)
+
+          if (warning) {
+            this.logger.warn?.(warning)
+          }
+
+          if (deprecated && !warnedCritters) {
+            warnedCritters = true
+            this.logger.warn?.(CRITTERS_DEPRECATION_WARNING)
+          }
 
           if (command) {
             switch (command) {

--- a/packages/beasties/test/directives.test.ts
+++ b/packages/beasties/test/directives.test.ts
@@ -1,0 +1,81 @@
+import type { Logger } from '../src/types'
+
+import { describe, expect, it, vi } from 'vitest'
+import { compileSheet } from '../src/compiler'
+import Beasties from '../src/index'
+
+const HTML = `<html><head><link rel="stylesheet" href="/style.css"></head><body><h1>Hi</h1></body></html>`
+
+function createTestLogger() {
+  const logger: Logger = {
+    warn: () => {},
+    info: () => {},
+    error: () => {},
+    debug: () => {},
+  }
+  return { logger, warn: vi.spyOn(logger, 'warn') }
+}
+
+async function classic(css: string, logger?: Logger) {
+  const beasties = new Beasties({
+    reduceInlineStyles: false,
+    path: '/',
+    logLevel: 'warn',
+    preload: false,
+    logger,
+  })
+  beasties.readFile = () => css
+  const result = await beasties.process(HTML)
+  return [...result.matchAll(/<style>([\s\S]*?)<\/style>/g)].map(m => m[1]).join('')
+}
+
+describe('critters: alias', () => {
+  it('should honour critters: directives at runtime', async () => {
+    const { logger, warn } = createTestLogger()
+    const css = await classic(`/* critters:include */\n.not-present { color: red; }\n/* critters:exclude */\nh1 { color: blue; }`, logger)
+
+    expect(css).toBe('.not-present{color:red}')
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledWith('Found deprecated "critters:" comment directives. Use the "beasties:" prefix instead, for example "/* beasties:include start */".')
+  })
+
+  it('should honour critters: directives at compile time', () => {
+    const sheet = compileSheet(`/* critters:include start */\n.not-present { color: red; }\n/* critters:include end */`)
+
+    expect(sheet.rules[0]!.always).toBe(true)
+    expect(sheet.warnings).toEqual(['Found deprecated "critters:" comment directives. Use the "beasties:" prefix instead, for example "/* beasties:include start */".'])
+  })
+})
+
+describe('unrecognised directives', () => {
+  it('should warn on a misspelled command at runtime', async () => {
+    const { logger, warn } = createTestLogger()
+    await classic(`/* beasties:inclde */\n.not-present { color: red; }`, logger)
+
+    expect(warn).toHaveBeenCalledWith('Unknown comment directive "beasties:inclde". Supported directives are: beasties:include, beasties:exclude, beasties:include start, beasties:include end, beasties:exclude start, beasties:exclude end.')
+  })
+
+  it('should warn on an unknown namespace at compile time', () => {
+    const sheet = compileSheet(`/* critter:include */\n.not-present { color: red; }`)
+
+    expect(sheet.warnings).toEqual(['Ignoring unrecognised comment directive "critter:include". Did you mean "beasties:include"?'])
+    expect(sheet.rules[0]!.always).toBeUndefined()
+  })
+
+  it.each([
+    '/*! beasties:include */',
+    '/*! Copyright 2018 Google LLC. Licensed under Apache-2.0 */',
+    '/* Copyright 2018 Google LLC: include the license in redistributions */',
+    '/*# sourceMappingURL=style.css.map */',
+    '/* TODO: exclude this once the redesign lands */',
+    '/* note: include start */',
+    '/* https://example.com/docs#include */',
+  ])('should stay quiet for %s', async (comment) => {
+    const { logger, warn } = createTestLogger()
+    const css = `${comment}\nh1 { color: blue; }`
+    await classic(css, logger)
+
+    expect(warn).not.toHaveBeenCalled()
+    expect(compileSheet(css).warnings).toEqual([])
+  })
+})


### PR DESCRIPTION
users following the Critters docs might still be using `/* critters:include start */` or similar

we now honour that prefix + warn when we encounter comments that look like directives but aren't
