### PR TITLE
fix(beasties): reject unsafe media values before emitting `onload` handlers

### DIFF
--- a/packages/beasties/src/index.ts
+++ b/packages/beasties/src/index.ts
@@ -25,6 +25,7 @@ import path from 'node:path'
 import { applyMarkedSelectors, markOnly, parseStylesheet, serializeStylesheet, validateMediaQuery, walkStyleRules, walkStyleRulesWithReverseMirror } from './css'
 import { CRITTERS_DEPRECATION_WARNING, parseDirective } from './directives'
 import { createDocument, serializeDocument } from './dom'
+import { isSafeMediaValue } from './media'
 import { isAlwaysCriticalSelector, normalizeCssSelector } from './selectors'
 import { REMOTE_URL_RE, resolveCssUrl, rewriteCssUrls } from './urls'
 import { createLogger, isSubpath } from './util'
@@ -343,7 +344,7 @@ export default class Beasties {
 
     let media: string | undefined = link.getAttribute('media')
 
-    if (media && !validateMediaQuery(media)) {
+    if (media && (!validateMediaQuery(media) || !isSafeMediaValue(media))) {
       media = undefined
     }
     const preloadMode = this.options.preload

--- a/packages/beasties/src/media.ts
+++ b/packages/beasties/src/media.ts
@@ -1,0 +1,13 @@
+/**
+ * Conservative allowlist for re-emitting a `media` attribute value into
+ * generated JavaScript. `validateMediaQuery()` parses the query but tolerates
+ * quotes and semicolons, which would break out of the `onload` handler that the
+ * `media` and `js*` strategies build.
+ *
+ * @see https://github.com/angular/angular-cli/issues/33342
+ */
+const SAFE_MEDIA_RE = /^[\w\s\-(),:.]+$/
+
+export function isSafeMediaValue(media: string): boolean {
+  return SAFE_MEDIA_RE.test(media)
+}

--- a/packages/beasties/src/runtime.ts
+++ b/packages/beasties/src/runtime.ts
@@ -10,6 +10,7 @@
 
 import type { AttrTest, CompiledRule, CompiledSheet, CompoundTest, SelectorMatch, StructuralProgram } from './compiler'
 import type { CompactPlan } from './plan'
+import { isSafeMediaValue } from './media'
 import { isCompactPlan } from './plan'
 import { decodePlan } from './plan-decode'
 
@@ -825,10 +826,6 @@ function fingerprintTokens(tokens: DocumentTokens): string {
 const CSS_HREF_RE = /\.css(?:[?#]|$)/i
 const LINK_TAG_RE = /<link\b(?:[^>"']|"[^"]*"|'[^']*')*>/gi
 const REL_STYLESHEET_RE = /\brel\s*=\s*(?:"stylesheet"|'stylesheet'|stylesheet(?=[\s>]))/i
-// conservative allowlist so a media attribute can be re-emitted into onload
-// javascript without any possibility of attribute or script breakout
-const SAFE_MEDIA_RE = /^[\w\s\-(),:.]+$/
-
 const CSS_LOADER_PREAMBLE = 'function $loadcss(u,m,l){(l=document.createElement(\'link\')).rel=\'stylesheet\';l.href=u;document.head.appendChild(l)}'
 const CSS_LOADER_LAZY_PREAMBLE = CSS_LOADER_PREAMBLE.replace(
   'l.href',
@@ -1106,7 +1103,7 @@ export function createProcessor(plans: Array<CompiledSheet | CompactPlan>, optio
       }
 
       const rawMedia = getAttr(tag, 'media')
-      const media = rawMedia && SAFE_MEDIA_RE.test(rawMedia) ? rawMedia : undefined
+      const media = rawMedia && isSafeMediaValue(rawMedia) ? rawMedia : undefined
       let newTag = tag
       let noscriptFallback = false
       let scriptAfter: string | undefined

--- a/packages/beasties/test/security.test.ts
+++ b/packages/beasties/test/security.test.ts
@@ -65,4 +65,20 @@ describe('beasties', () => {
     `)
     expect(hasEvilScript(html)).toBeFalsy()
   })
+
+  it('should not let a quote-bearing media value break out of the onload handler', async () => {
+    const beasties = new Beasties({ preload: 'media', logLevel: 'silent' })
+    beasties.readFile = () => `h1 { color: red }`
+    const html = await beasties.process(`
+        <html>
+            <head>
+                <link rel=stylesheet href="/style.css" media="all';alert(1);'">
+            </head>
+            <body>
+                <h1>hi</h1>
+            </body>
+    `)
+    expect(html).toContain(`onload="this.media='all'"`)
+    expect(html).not.toMatch(/onload="[^"]*alert/)
+  })
 })


### PR DESCRIPTION
this isn't a security issue as we're processing _user-authored_ code ... but previously `validateMediaQuery()` wasn't quite thorough enough when handling the write for `onload` ...

the runtime path was already guarded by an allowlist, so this extracts allowlist for use in both paths

Media queries using characters outside `[\w\s\-(),:.]` now degrade to `media="all"` on the PostCSS path, matching what the compiled path has always done.

related: https://github.com/angular/angular-cli/issues/33342