### PR TITLE
feat(beasties): add `nonce` option and csp-safe `media-script` preload strategy

### DIFF
--- a/packages/beasties/README.md
+++ b/packages/beasties/README.md
@@ -130,6 +130,7 @@ All optional. Pass them to `new Beasties({ ... })`.
 - `allowRules` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [RegExp](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp)>** Always include rules matching these selectors or patterns in the critical CSS, regardless of whether they match elements in the document. _(default: `[]`)_
 - `preload` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Which [preload strategy](#preloadstrategy) to use
 - `noscriptFallback` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Add `<noscript>` fallback to JS-based strategies
+- `nonce` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** CSP nonce to set on every `<style>` and `<script>` element beasties injects
 - `inlineFonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Inline critical font-face rules _(default: `false`)_
 - `preloadFonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Preloads critical fonts _(default: `true`)_
 - `fonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Shorthand for setting `inlineFonts` + `preloadFonts`\* Values:
@@ -282,6 +283,30 @@ If a stylesheet should not be processed by Beasties — for example a file that 
 
 Beasties will not read, inline, prune, or mutate that tag regardless of the active preload strategy. This is useful when disabling `inlineCritical` globally would sacrifice Core Web Vitals optimizations for the rest of your stylesheets.
 
+### Content Security Policy
+
+All preload strategies other than `"body"`, `"media-script"` and `preload: false` rely on an inline `onload` attribute or an inline `<script>`, both of which are blocked under a strict CSP (`script-src-attr 'none'`, or `strict-dynamic` alongside a hash or nonce, which makes `'unsafe-inline'` inert).
+
+To defer non-critical CSS under a strict CSP, use `preload: 'media-script'` with a `nonce`:
+
+```js
+const beasties = new Beasties({
+  preload: 'media-script',
+  nonce: requestNonce,
+})
+```
+
+Deferred links are left as `media="print"` with the real media value in `data-beasties-media`, and a single script restores them:
+
+```html
+<link rel="stylesheet" href="/style.css" media="print" data-beasties-media="all">
+<noscript><link rel="stylesheet" href="/style.css"></noscript>
+<!-- ...at the end of <body> -->
+<script nonce="...">document.querySelectorAll('link[data-beasties-media]').forEach(function(l){l.media=l.getAttribute('data-beasties-media');l.removeAttribute('data-beasties-media')})</script>
+```
+
+Exactly one script is emitted per document and its body never varies, so if you cannot supply a nonce you can allow it with a static `script-src` hash instead.
+
 ### Logger
 
 Custom logger interface:
@@ -320,6 +345,7 @@ Note: <kbd>JS</kbd> indicates a strategy requiring JavaScript (falls back to `<n
 - **default:** Move stylesheet links to the end of the document and insert preload meta tags in their place.
 - **"body":** Move all external stylesheet links to the end of the document.
 - **"media":** Load stylesheets asynchronously by adding `media="not x"` and removing once loaded. <kbd>JS</kbd>
+- **"media-script":** Like `"media"`, but instead of an inline `onload` handler the deferred links are marked with `data-beasties-media` and a single script at the end of `<body>` restores their media. The script body is invariant, so it can be allowed with a CSP hash or with `options.nonce`. <kbd>JS</kbd>
 - **"swap":** Convert stylesheet links to preloads that swap to `rel="stylesheet"` once loaded ([details](https://www.filamentgroup.com/lab/load-css-simpler/#the-code)). <kbd>JS</kbd>
 - **"swap-high":** Use `<link rel="alternate stylesheet preload">` and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-high.html)). <kbd>JS</kbd>
 - **"swap-low":** Use `<link rel="alternate stylesheet">` (no `preload` in `rel` here!) and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-low.html)). It ensures lowest priority compared to `swap` and `swap-high`. <kbd>JS</kbd>
@@ -327,7 +353,7 @@ Note: <kbd>JS</kbd> indicates a strategy requiring JavaScript (falls back to `<n
 - **"js-lazy":** Like `"js"`, but the stylesheet is disabled until fully loaded.
 - **false:** Disables adding preload tags.
 
-Type: (default | `"body"` | `"media"` | `"swap"` | `"swap-high"` | `"swap-low"` | `"js"` | `"js-lazy"`)
+Type: (default | `"body"` | `"media"` | `"media-script"` | `"swap"` | `"swap-high"` | `"swap-low"` | `"js"` | `"js-lazy"`)
 
 ## Similar Libraries
 

--- a/packages/beasties/src/index.d.ts
+++ b/packages/beasties/src/index.d.ts
@@ -56,8 +56,9 @@ export interface Options {
   pruneSource?: boolean
   mergeStylesheets?: boolean
   additionalStylesheets?: string[]
-  preload?: 'body' | 'media' | 'swap' | 'swap-high' | 'swap-low' | 'js' | 'js-lazy'
+  preload?: 'body' | 'media' | 'media-script' | 'swap' | 'swap-high' | 'swap-low' | 'js' | 'js-lazy'
   noscriptFallback?: boolean
+  nonce?: string
   inlineFonts?: boolean
   preloadFonts?: boolean
   allowRules?: Array<string | RegExp>

--- a/packages/beasties/src/index.ts
+++ b/packages/beasties/src/index.ts
@@ -38,6 +38,9 @@ const WHITESPACE_RE = /\s+/
 // eslint-disable-next-line regexp/no-super-linear-backtracking,regexp/no-misleading-capturing-group
 const URL_RE = /url\s*\(\s*(['"]?)(.+?)\1\s*\)/
 
+const DEFERRED_MEDIA_ATTR = 'data-beasties-media'
+const DEFERRED_MEDIA_SCRIPT = `document.querySelectorAll('link[${DEFERRED_MEDIA_ATTR}]').forEach(function(l){l.media=l.getAttribute('${DEFERRED_MEDIA_ATTR}');l.removeAttribute('${DEFERRED_MEDIA_ATTR}')})`
+
 interface PreFetchedStylesheet {
   link: ChildNode
   href: string
@@ -145,6 +148,10 @@ export default class Beasties {
       }
     }
 
+    if (this.options.preload === 'media-script') {
+      this.injectDeferredMediaScript(document)
+    }
+
     // go through all the style tags in the document and reduce them to only critical CSS
     const styles = this.getAffectedStyleTags(document)
     for (const style of styles) {
@@ -173,6 +180,27 @@ export default class Beasties {
       return styles.filter(style => style.$$external)
     }
     return styles
+  }
+
+  /**
+   * Append the single deferred-CSS activation script used by the `"media-script"`
+   * strategy, if any link was actually deferred. The script body is invariant, so
+   * it can be covered by a CSP hash as well as by `options.nonce`.
+   */
+  private injectDeferredMediaScript(document: HTMLDocument) {
+    if (document.querySelectorAll(`link[${DEFERRED_MEDIA_ATTR}]`).length === 0) {
+      return
+    }
+    const script = document.createElement('script')
+    this.applyNonce(script)
+    script.textContent = DEFERRED_MEDIA_SCRIPT
+    document.body.appendChild(script)
+  }
+
+  private applyNonce(element: Node) {
+    if (this.options.nonce) {
+      element.setAttribute('nonce', this.options.nonce)
+    }
   }
 
   mergeStylesheets(document: HTMLDocument): void {
@@ -283,6 +311,7 @@ export default class Beasties {
         }
         styleSheetsIncluded.push(cssFile)
         const style = document.createElement('style')
+        this.applyNonce(style)
         style.$$external = true
         style.$$name = cssFile
         return this.getCssAsset(cssFile, style).then(sheet => [sheet, style] as const)
@@ -316,6 +345,7 @@ export default class Beasties {
 
     // dreate style element early so subclasses can use it in getCssAsset
     const style = document.createElement('style')
+    this.applyNonce(style)
     style.$$external = true
 
     const sheet = await this.getCssAsset(href, style)
@@ -373,6 +403,7 @@ export default class Beasties {
     else {
       if (preloadMode === 'js' || preloadMode === 'js-lazy') {
         const script = document.createElement('script')
+        this.applyNonce(script)
         script.setAttribute('data-href', href)
         script.setAttribute('data-media', media || 'all')
         const js = `${cssLoaderPreamble}$loadcss(document.currentScript.dataset.href,document.currentScript.dataset.media)`
@@ -383,6 +414,11 @@ export default class Beasties {
         cssLoaderPreamble = ''
         noscriptFallback = true
         updateLinkToPreload = true
+      }
+      else if (preloadMode === 'media-script') {
+        link.setAttribute('media', 'print')
+        link.setAttribute(DEFERRED_MEDIA_ATTR, media || 'all')
+        noscriptFallback = true
       }
       else if (preloadMode === 'media') {
         // @see https://github.com/filamentgroup/loadCSS/blob/af1106cfe0bf70147e22185afa7ead96c01dec48/src/loadCSS.js#L26

--- a/packages/beasties/src/runtime.ts
+++ b/packages/beasties/src/runtime.ts
@@ -764,7 +764,7 @@ function ruleText(rule: CompiledRule, tokens: DocumentTokens, invert = false): s
  * The mechanism to use for lazy-loading stylesheets, mirroring the classic
  * beasties `preload` option.
  */
-export type PreloadStrategy = 'body' | 'media' | 'swap' | 'swap-high' | 'swap-low' | 'js' | 'js-lazy'
+export type PreloadStrategy = 'body' | 'media' | 'media-script' | 'swap' | 'swap-high' | 'swap-low' | 'js' | 'js-lazy'
 
 export interface ProcessorOptions extends RuntimeOptions {
   /**
@@ -776,6 +776,10 @@ export interface ProcessorOptions extends RuntimeOptions {
    * Add `<noscript>` fallback to JS-based strategies _(default: `true`)_
    */
   noscriptFallback?: boolean
+  /**
+   * CSP nonce to set on every `<style>` and `<script>` element beasties injects
+   */
+  nonce?: string
   /**
    * Cache rendered critical CSS keyed by the set of tokens found in the
    * document, so pages with the same shape don't re-evaluate the compiled
@@ -826,12 +830,16 @@ function fingerprintTokens(tokens: DocumentTokens): string {
 const CSS_HREF_RE = /\.css(?:[?#]|$)/i
 const LINK_TAG_RE = /<link\b(?:[^>"']|"[^"]*"|'[^']*')*>/gi
 const REL_STYLESHEET_RE = /\brel\s*=\s*(?:"stylesheet"|'stylesheet'|stylesheet(?=[\s>]))/i
+
 const CSS_LOADER_PREAMBLE = 'function $loadcss(u,m,l){(l=document.createElement(\'link\')).rel=\'stylesheet\';l.href=u;document.head.appendChild(l)}'
 const CSS_LOADER_LAZY_PREAMBLE = CSS_LOADER_PREAMBLE.replace(
   'l.href',
   'l.media=\'print\';l.onload=function(){l.media=m};l.href',
 )
 const CSS_LOADER_INVOKE = '$loadcss(document.currentScript.dataset.href,document.currentScript.dataset.media)'
+
+const DEFERRED_MEDIA_ATTR = 'data-beasties-media'
+const DEFERRED_MEDIA_SCRIPT = `document.querySelectorAll('link[${DEFERRED_MEDIA_ATTR}]').forEach(function(l){l.media=l.getAttribute('${DEFERRED_MEDIA_ATTR}');l.removeAttribute('${DEFERRED_MEDIA_ATTR}')})`
 
 function attrValueRegex(name: string): RegExp {
   return new RegExp(`(^|\\s)(${name})\\s*=\\s*("[^"]*"|'[^']*'|[^\\s>]+)`, 'i')
@@ -964,6 +972,7 @@ export function createProcessor(plans: Array<CompiledSheet | CompactPlan>, optio
   // the inverse is only needed to compare against `minimumExternalSize`
   const renderOptions = { ...options, inverse: !!options.minimumExternalSize }
   const fullCssCache = new Map<CompiledSheet, string>()
+  const nonceAttr = options.nonce ? ` nonce="${escapeAttr(options.nonce)}"` : ''
 
   function fullCss(sheet: CompiledSheet): string {
     let css = fullCssCache.get(sheet)
@@ -1055,6 +1064,7 @@ export function createProcessor(plans: Array<CompiledSheet | CompactPlan>, optio
     let firstLinkIndex = -1
     const edits: Edit[] = []
     const bodyAppends: string[] = []
+    let deferredMedia = false
     const criticalParts: string[] = []
     const fontPreloads = new Set<string>()
     let isFirstSheet = true
@@ -1112,6 +1122,11 @@ export function createProcessor(plans: Array<CompiledSheet | CompactPlan>, optio
         bodyAppends.push(tag)
         newTag = ''
       }
+      else if (strategy === 'media-script') {
+        newTag = setAttr(setAttr(tag, 'media', 'print'), DEFERRED_MEDIA_ATTR, media || 'all')
+        deferredMedia = true
+        noscriptFallback = true
+      }
       else if (strategy === 'media') {
         newTag = setAttr(setAttr(tag, 'media', 'print'), 'onload', `this.media='${media || 'all'}'`)
         noscriptFallback = true
@@ -1130,7 +1145,7 @@ export function createProcessor(plans: Array<CompiledSheet | CompactPlan>, optio
       }
       else if (strategy === 'js' || strategy === 'js-lazy') {
         const preamble = isFirstSheet ? (strategy === 'js-lazy' ? CSS_LOADER_LAZY_PREAMBLE : CSS_LOADER_PREAMBLE) : ''
-        scriptAfter = `<script data-href="${escapeAttr(href)}" data-media="${escapeAttr(media || 'all')}">${preamble}${CSS_LOADER_INVOKE}</script>`
+        scriptAfter = `<script${nonceAttr} data-href="${escapeAttr(href)}" data-media="${escapeAttr(media || 'all')}">${preamble}${CSS_LOADER_INVOKE}</script>`
         newTag = toPreload(tag)
         noscriptFallback = true
       }
@@ -1170,7 +1185,11 @@ export function createProcessor(plans: Array<CompiledSheet | CompactPlan>, optio
       headInsertions.push(`<link rel="preload" as="font" crossorigin="anonymous" href="${escapeAttr(preload)}">`)
     }
     if (critical) {
-      headInsertions.push(`<style>${critical}</style>`)
+      headInsertions.push(`<style${nonceAttr}>${critical}</style>`)
+    }
+
+    if (deferredMedia) {
+      bodyAppends.push(`<script${nonceAttr}>${DEFERRED_MEDIA_SCRIPT}</script>`)
     }
 
     if (headInsertions.length > 0) {

--- a/packages/beasties/src/types.ts
+++ b/packages/beasties/src/types.ts
@@ -8,6 +8,7 @@ import type { Logger, LogLevel } from './util'
  * - **default:** Move stylesheet links to the end of the document and insert preload meta tags in their place.
  * - **"body":** Move all external stylesheet links to the end of the document.
  * - **"media":** Load stylesheets asynchronously by adding `media="not x"` and removing once loaded. <kbd>JS</kbd>
+ * - **"media-script":** Like `"media"`, but instead of an inline `onload` handler the deferred links are marked with `data-beasties-media` and a single script (with an invariant body, so it can be allowed by CSP hash or `nonce`) restores their media. <kbd>JS</kbd>
  * - **"swap":** Convert stylesheet links to preloads that swap to `rel="stylesheet"` once loaded ([details](https://www.filamentgroup.com/lab/load-css-simpler/#the-code)). <kbd>JS</kbd>
  * - **"swap-high":** Use `<link rel="alternate stylesheet preload">` and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-high.html)). <kbd>JS</kbd>
  * - **"swap-low":** Use `<link rel="alternate stylesheet">` (no `preload` in `rel` here!) and swap to `rel="stylesheet"` once loaded ([details](http://filamentgroup.github.io/loadCSS/test/new-low.html)). It ensures lowest priority compared to `swap` and `swap-high`. <kbd>JS</kbd>
@@ -15,7 +16,7 @@ import type { Logger, LogLevel } from './util'
  * - **"js-lazy":** Like `"js"`, but the stylesheet is disabled until fully loaded.
  * - **false:** Disables adding preload tags.
  */
-type PreloadStrategy = 'body' | 'media' | 'swap' | 'swap-high' | 'swap-low' | 'js' | 'js-lazy'
+type PreloadStrategy = 'body' | 'media' | 'media-script' | 'swap' | 'swap-high' | 'swap-low' | 'js' | 'js-lazy'
 
 /**
  * Controls which keyframes rules are inlined.
@@ -72,6 +73,10 @@ export interface Options {
    * Add `<noscript>` fallback to JS-based strategies
    */
   noscriptFallback?: boolean
+  /**
+   * CSP nonce to set on every `<style>` and `<script>` element beasties injects
+   */
+  nonce?: string
   /**
    * Inline critical font-face rules _(default: `false`)_
    */

--- a/packages/beasties/test/csp.test.ts
+++ b/packages/beasties/test/csp.test.ts
@@ -115,7 +115,7 @@ describe('"media-script" preload mode (classic)', () => {
       html(`<link rel="stylesheet" href="/style.css" media="all';alert(1);'">`),
     )
     expect(result).toContain('data-beasties-media="all"')
-    expect(result.match(/<script[^>]*>[\s\S]*?<\/script>/g)).toEqual([`<script>${DEFERRED_SCRIPT}</script>`])
+    expect(result.match(/<script[^>]*>[\s\S]*?<\/script>/gi)).toEqual([`<script>${DEFERRED_SCRIPT}</script>`])
   })
 })
 
@@ -167,6 +167,6 @@ describe('"media-script" preload mode (compiled)', () => {
       html(`<link rel="stylesheet" href="/style.css" media="all';alert(1);'">`),
     )
     expect(result).toContain('data-beasties-media="all"')
-    expect(result.match(/<script[^>]*>[\s\S]*?<\/script>/g)).toEqual([`<script>${DEFERRED_SCRIPT}</script>`])
+    expect(result.match(/<script[^>]*>[\s\S]*?<\/script>/gi)).toEqual([`<script>${DEFERRED_SCRIPT}</script>`])
   })
 })

--- a/packages/beasties/test/csp.test.ts
+++ b/packages/beasties/test/csp.test.ts
@@ -1,3 +1,4 @@
+import { DomUtils, parseDocument } from 'htmlparser2'
 import { describe, expect, it } from 'vitest'
 
 import { compileSheet } from '../src/compiler'
@@ -7,6 +8,11 @@ import { createProcessor } from '../src/runtime'
 const CSS = 'h1 { color: blue; }'
 
 const DEFERRED_SCRIPT = `document.querySelectorAll('link[data-beasties-media]').forEach(function(l){l.media=l.getAttribute('data-beasties-media');l.removeAttribute('data-beasties-media')})`
+
+function scriptContents(html: string): string[] {
+  const document = parseDocument(html)
+  return DomUtils.findAll(node => node.tagName === 'script', document.children).map(node => DomUtils.textContent(node))
+}
 
 function classic(options: ConstructorParameters<typeof Beasties>[0] = {}) {
   const beasties = new Beasties({
@@ -115,7 +121,7 @@ describe('"media-script" preload mode (classic)', () => {
       html(`<link rel="stylesheet" href="/style.css" media="all';alert(1);'">`),
     )
     expect(result).toContain('data-beasties-media="all"')
-    expect(result.match(/<script[^>]*>[\s\S]*?<\/script>/gi)).toEqual([`<script>${DEFERRED_SCRIPT}</script>`])
+    expect(scriptContents(result)).toEqual([DEFERRED_SCRIPT])
   })
 })
 
@@ -167,6 +173,6 @@ describe('"media-script" preload mode (compiled)', () => {
       html(`<link rel="stylesheet" href="/style.css" media="all';alert(1);'">`),
     )
     expect(result).toContain('data-beasties-media="all"')
-    expect(result.match(/<script[^>]*>[\s\S]*?<\/script>/gi)).toEqual([`<script>${DEFERRED_SCRIPT}</script>`])
+    expect(scriptContents(result)).toEqual([DEFERRED_SCRIPT])
   })
 })

--- a/packages/beasties/test/csp.test.ts
+++ b/packages/beasties/test/csp.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+
+import { compileSheet } from '../src/compiler'
+import Beasties from '../src/index'
+import { createProcessor } from '../src/runtime'
+
+const CSS = 'h1 { color: blue; }'
+
+const DEFERRED_SCRIPT = `document.querySelectorAll('link[data-beasties-media]').forEach(function(l){l.media=l.getAttribute('data-beasties-media');l.removeAttribute('data-beasties-media')})`
+
+function classic(options: ConstructorParameters<typeof Beasties>[0] = {}) {
+  const beasties = new Beasties({
+    reduceInlineStyles: false,
+    path: '/',
+    logLevel: 'silent',
+    ...options,
+  })
+  beasties.readFile = () => CSS
+  return beasties
+}
+
+function html(links = '<link rel="stylesheet" href="/style.css">') {
+  return `<html><head>${links}</head><body><h1>Hello World!</h1></body></html>`
+}
+
+function compiled(options: Parameters<typeof createProcessor>[1], hrefs = ['style.css']) {
+  return createProcessor(hrefs.map(href => compileSheet(CSS, { href })), options)
+}
+
+describe('nonce (classic)', () => {
+  it('should set the nonce on the inlined style', async () => {
+    const result = await classic({ nonce: 'abc123', preload: false }).process(html())
+    expect(result).toContain('<style nonce="abc123">h1{color:blue}</style>')
+  })
+
+  it('should set the nonce on additional stylesheets', async () => {
+    const beasties = classic({ nonce: 'abc123', preload: false, additionalStylesheets: ['/extra.css'] })
+    const result = await beasties.process(html(''))
+    expect(result).toContain('<style nonce="abc123">h1{color:blue}</style>')
+  })
+
+  it('should set the nonce on the "js" loader script', async () => {
+    const result = await classic({ nonce: 'abc123', preload: 'js' }).process(html())
+    expect(result).toContain('<script nonce="abc123" data-href="/style.css" data-media="all">')
+  })
+
+  it('should escape a quote-bearing nonce', async () => {
+    const result = await classic({ nonce: 'a"><b>', preload: false }).process(html())
+    expect(result).toContain('<style nonce="a&quot;><b>">')
+  })
+})
+
+describe('nonce (compiled)', () => {
+  it('should set the nonce on the inlined style', () => {
+    const result = compiled({ nonce: 'abc123', preload: false }).process(html())
+    expect(result).toContain('<style nonce="abc123">h1{color:blue}</style>')
+  })
+
+  it('should set the nonce on the "js" loader script', () => {
+    const result = compiled({ nonce: 'abc123', preload: 'js' }).process(html())
+    expect(result).toContain('<script nonce="abc123" data-href="/style.css" data-media="all">')
+  })
+
+  it('should escape a quote-bearing nonce', () => {
+    const result = compiled({ nonce: 'a"><b>', preload: false }).process(html())
+    expect(result).toContain('<style nonce="a&quot;><b>">')
+  })
+})
+
+describe('"media-script" preload mode (classic)', () => {
+  it('should defer links without an inline event handler', async () => {
+    const result = await classic({ preload: 'media-script' }).process(html())
+    expect(result).not.toContain('onload')
+    expect(result).toContain('<link rel="stylesheet" href="/style.css" media="print" data-beasties-media="all">')
+    expect(result).toContain(`<script>${DEFERRED_SCRIPT}</script></body>`)
+  })
+
+  it('should emit a single script for multiple stylesheets', async () => {
+    const result = await classic({ preload: 'media-script' }).process(
+      html('<link rel="stylesheet" href="/style.css"><link rel="stylesheet" href="/other.css">'),
+    )
+    expect(result.match(/<script/g)).toHaveLength(1)
+    expect(result.match(/data-beasties-media="all"/g)).toHaveLength(2)
+  })
+
+  it('should set the nonce on the script', async () => {
+    const result = await classic({ preload: 'media-script', nonce: 'abc123' }).process(html())
+    expect(result).toContain(`<script nonce="abc123">${DEFERRED_SCRIPT}</script>`)
+  })
+
+  it('should emit a noscript fallback', async () => {
+    const result = await classic({ preload: 'media-script' }).process(html())
+    expect(result).toContain('<noscript><link rel="stylesheet" href="/style.css"></noscript>')
+  })
+
+  it('should omit the noscript fallback when disabled', async () => {
+    const result = await classic({ preload: 'media-script', noscriptFallback: false }).process(html())
+    expect(result).not.toContain('<noscript>')
+  })
+
+  it('should not emit a script when no link was deferred', async () => {
+    const result = await classic({ preload: 'media-script' }).process(html(''))
+    expect(result).not.toContain('<script')
+  })
+
+  it('should preserve a valid media query', async () => {
+    const result = await classic({ preload: 'media-script' }).process(
+      html('<link rel="stylesheet" href="/style.css" media="screen and (min-width: 480px)">'),
+    )
+    expect(result).toContain('data-beasties-media="screen and (min-width: 480px)"')
+  })
+
+  it('should not let a quote-bearing media value reach executable context', async () => {
+    const result = await classic({ preload: 'media-script' }).process(
+      html(`<link rel="stylesheet" href="/style.css" media="all';alert(1);'">`),
+    )
+    expect(result).toContain('data-beasties-media="all"')
+    expect(result.match(/<script[^>]*>[\s\S]*?<\/script>/g)).toEqual([`<script>${DEFERRED_SCRIPT}</script>`])
+  })
+})
+
+describe('"media-script" preload mode (compiled)', () => {
+  it('should defer links without an inline event handler', () => {
+    const result = compiled({ preload: 'media-script' }).process(html())
+    expect(result).not.toContain('onload')
+    expect(result).toContain('<link rel="stylesheet" href="/style.css" media="print" data-beasties-media="all">')
+    expect(result).toContain(`<script>${DEFERRED_SCRIPT}</script>`)
+  })
+
+  it('should emit a single script for multiple stylesheets', () => {
+    const result = compiled({ preload: 'media-script' }, ['style.css', 'other.css']).process(
+      html('<link rel="stylesheet" href="/style.css"><link rel="stylesheet" href="/other.css">'),
+    )
+    expect(result.match(/<script/g)).toHaveLength(1)
+    expect(result.match(/data-beasties-media="all"/g)).toHaveLength(2)
+  })
+
+  it('should set the nonce on the script', () => {
+    const result = compiled({ preload: 'media-script', nonce: 'abc123' }).process(html())
+    expect(result).toContain(`<script nonce="abc123">${DEFERRED_SCRIPT}</script>`)
+  })
+
+  it('should emit a noscript fallback', () => {
+    const result = compiled({ preload: 'media-script' }).process(html())
+    expect(result).toContain('<noscript><link rel="stylesheet" href="/style.css"></noscript>')
+  })
+
+  it('should omit the noscript fallback when disabled', () => {
+    const result = compiled({ preload: 'media-script', noscriptFallback: false }).process(html())
+    expect(result).not.toContain('<noscript>')
+  })
+
+  it('should not emit a script when no link was deferred', () => {
+    const result = compiled({ preload: 'media-script' }).process(html(''))
+    expect(result).not.toContain('<script')
+  })
+
+  it('should preserve a valid media query', () => {
+    const result = compiled({ preload: 'media-script' }).process(
+      html('<link rel="stylesheet" href="/style.css" media="screen and (min-width: 480px)">'),
+    )
+    expect(result).toContain('data-beasties-media="screen and (min-width: 480px)"')
+  })
+
+  it('should not let a quote-bearing media value reach executable context', () => {
+    const result = compiled({ preload: 'media-script' }).process(
+      html(`<link rel="stylesheet" href="/style.css" media="all';alert(1);'">`),
+    )
+    expect(result).toContain('data-beasties-media="all"')
+    expect(result.match(/<script[^>]*>[\s\S]*?<\/script>/g)).toEqual([`<script>${DEFERRED_SCRIPT}</script>`])
+  })
+})


### PR DESCRIPTION
previously, every preload strategy except `body` emitted an inline `onload=` or a bare inline `<script>`

this was incompatible with strict-CSP users, so this now adds a `nonce` option that gets applied to every injected `<style>` and `<script>`, and a `media-script` strategy that defers via a marker attribute plus one invariant, hashable script per document

resolves https://github.com/angular/angular-cli/issues/32522, https://github.com/angular/angular-cli/issues/21683, https://github.com/angular/angular-cli/issues/20864, https://github.com/angular/angular-cli/issues/29603, https://github.com/angular/angular-cli/issues/29958, https://github.com/angular/angular/issues/68271 and resolves https://github.com/danielroe/beasties/issues/293.