### PR TITLE
feat(beasties): deduplicate repeated warnings

### DIFF
--- a/packages/beasties/README.md
+++ b/packages/beasties/README.md
@@ -144,6 +144,7 @@ All optional. Pass them to `new Beasties({ ... })`.
 - `safeParser` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Use PostCSS safe parser for fault-tolerant CSS parsing. Handles legacy code with syntax errors _(default: `true`)_
 - `logLevel` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Controls [log level](#loglevel) of the plugin _(default: `"info"`)_
 - `logger` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Provide a custom logger interface [logger](#logger)
+- `dedupeWarnings` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Suppress repeated identical warnings and errors, either `"process"`-wide (within a one minute window), per `"instance"`, or `false` to emit every message _(default: `"process"`)_
 
 ### Include/exclude rules
 

--- a/packages/beasties/src/index.d.ts
+++ b/packages/beasties/src/index.d.ts
@@ -69,6 +69,7 @@ export interface Options {
   logLevel?: 'info' | 'warn' | 'error' | 'trace' | 'debug' | 'silent'
   reduceInlineStyles?: boolean
   logger?: Logger
+  dedupeWarnings?: 'process' | 'instance' | false | true
 }
 
 export interface Logger {

--- a/packages/beasties/src/index.ts
+++ b/packages/beasties/src/index.ts
@@ -28,7 +28,7 @@ import { createDocument, serializeDocument } from './dom'
 import { isSafeMediaValue } from './media'
 import { isAlwaysCriticalSelector, normalizeCssSelector } from './selectors'
 import { REMOTE_URL_RE, resolveCssUrl, rewriteCssUrls } from './urls'
-import { createLogger, isSubpath } from './util'
+import { createDeduplicatingLogger, createLogger, isSubpath } from './util'
 
 const LEADING_SLASH_OR_QUERY_RE = /^\/(?!\/)|[?#].*$/g
 const PUBLIC_PATH_RE = /(^\/(?!\/)|\/$)/g
@@ -50,7 +50,7 @@ interface PreFetchedStylesheet {
 
 export default class Beasties {
   #selectorCache = new Map<string, string>()
-  options: Options & Required<Pick<Options, 'logLevel' | 'path' | 'publicPath' | 'reduceInlineStyles' | 'pruneSource' | 'additionalStylesheets'>> & { allowRules: Array<string | RegExp> }
+  options: Options & Required<Pick<Options, 'logLevel' | 'path' | 'publicPath' | 'reduceInlineStyles' | 'pruneSource' | 'additionalStylesheets' | 'dedupeWarnings'>> & { allowRules: Array<string | RegExp> }
   logger: Logger
   fs?: typeof import('node:fs')
 
@@ -63,9 +63,13 @@ export default class Beasties {
       pruneSource: false,
       additionalStylesheets: [],
       allowRules: [],
+      dedupeWarnings: 'process',
     }, options)
 
-    this.logger = this.options.logger || createLogger(this.options.logLevel)
+    this.logger = createDeduplicatingLogger(
+      this.options.logger || createLogger(this.options.logLevel),
+      this.options.dedupeWarnings === true ? 'process' : this.options.dedupeWarnings,
+    )
   }
 
   /**

--- a/packages/beasties/src/types.ts
+++ b/packages/beasties/src/types.ts
@@ -1,4 +1,4 @@
-import type { Logger, LogLevel } from './util'
+import type { DedupeScope, Logger, LogLevel } from './util'
 
 /**
  * The mechanism to use for lazy-loading stylesheets.
@@ -118,6 +118,10 @@ export interface Options {
    * Provide a custom logger interface {@link Logger logger}
    */
   logger?: Logger
+  /**
+   * Suppress repeated identical warnings and errors, within the given {@link DedupeScope scope} _(default: `"process"`)_
+   */
+  dedupeWarnings?: DedupeScope | true
 }
 
 export type { Logger }

--- a/packages/beasties/src/util.ts
+++ b/packages/beasties/src/util.ts
@@ -62,6 +62,68 @@ export function createLogger(logLevel: LogLevel): Logger {
   }, {})
 }
 
+/**
+ * Scope over which repeated warnings are suppressed.
+ *
+ * - **"process":** _(default)_ suppress messages already emitted anywhere in this process within the last minute.
+ * - **"instance":** suppress messages already emitted by this Beasties instance.
+ * - **false:** emit every message.
+ */
+export type DedupeScope = 'process' | 'instance' | false
+
+const DEDUPE_WINDOW_MS = 60_000
+const DEDUPE_MAX_ENTRIES = 500
+
+const processSeen = new Map<string, number>()
+
+/** Clear the process-wide record of emitted messages. */
+export function resetMessageDeduplication(): void {
+  processSeen.clear()
+}
+
+/**
+ * Wrap a logger so that identical `warn`/`error` messages are only emitted once
+ * per scope. Server-side rendering constructs a Beasties instance per request,
+ * so the default scope is the process.
+ */
+export function createDeduplicatingLogger(logger: Logger, scope: DedupeScope): Logger {
+  if (scope === false) {
+    return logger
+  }
+
+  const seen = scope === 'process' ? processSeen : new Map<string, number>()
+
+  const shouldEmit = (level: string, message: string) => {
+    const key = `${level}:${message}`
+    const now = Date.now()
+    const last = seen.get(key)
+    if (last !== undefined && now - last < DEDUPE_WINDOW_MS) {
+      return false
+    }
+    if (seen.size >= DEDUPE_MAX_ENTRIES) {
+      seen.clear()
+    }
+    seen.set(key, now)
+    return true
+  }
+
+  const deduped: Logger = { ...logger }
+
+  for (const level of ['warn', 'error'] as const) {
+    const original = logger[level]
+    if (!original) {
+      continue
+    }
+    deduped[level] = (message: string) => {
+      if (shouldEmit(level, message)) {
+        original.call(logger, message)
+      }
+    }
+  }
+
+  return deduped
+}
+
 export function isSubpath(basePath: string, currentPath: string): boolean {
   return !path.relative(basePath, currentPath).startsWith('..')
 }

--- a/packages/beasties/test/warnings-dedupe.test.ts
+++ b/packages/beasties/test/warnings-dedupe.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import Beasties from '../src/index'
+import { resetMessageDeduplication } from '../src/util'
+
+const html = `<html><head><link rel="stylesheet" href="/style.css"></head><body><p>Hello</p></body></html>`
+
+function makeBeasties(options: Record<string, unknown> = {}, css = 'p { color: red }') {
+  const warn = vi.fn()
+  const debug = vi.fn()
+  const beasties = new Beasties({
+    reduceInlineStyles: false,
+    path: '/',
+    logger: { warn, debug },
+    ...options,
+  })
+  beasties.readFile = () => css
+  return { beasties, warn, debug }
+}
+
+describe('warning deduplication', () => {
+  beforeEach(() => {
+    resetMessageDeduplication()
+  })
+
+  it('emits a repeated warning only once per instance', async () => {
+    const { beasties, warn } = makeBeasties({ dedupeWarnings: 'instance' })
+    beasties.readFile = () => Promise.reject(new Error('ENOENT'))
+
+    await beasties.process(html)
+    await beasties.process(html)
+
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits a repeated warning only once per process by default', async () => {
+    const first = makeBeasties()
+    const second = makeBeasties()
+    first.beasties.readFile = () => Promise.reject(new Error('ENOENT'))
+    second.beasties.readFile = () => Promise.reject(new Error('ENOENT'))
+
+    await first.beasties.process(html)
+    await second.beasties.process(html)
+
+    expect(first.warn).toHaveBeenCalledTimes(1)
+    expect(second.warn).not.toHaveBeenCalled()
+  })
+
+  it('emits every warning when deduplication is disabled', async () => {
+    const { beasties, warn } = makeBeasties({ dedupeWarnings: false })
+    beasties.readFile = () => Promise.reject(new Error('ENOENT'))
+
+    await beasties.process(html)
+    await beasties.process(html)
+
+    expect(warn).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not suppress distinct warnings', async () => {
+    const { beasties, warn } = makeBeasties()
+    beasties.readFile = filename => Promise.reject(new Error(`ENOENT ${filename}`))
+
+    await beasties.process(`<html><head><link rel="stylesheet" href="/a.css"><link rel="stylesheet" href="/b.css"></head><body></body></html>`)
+
+    expect(warn).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
in the event you're constructing a a new `Beasties` instance per request, a single issue will re-warn on every render 

in https://github.com/angular/angular-cli/issues/33203, one person logged ~155M lines in four days 🤯 

this PR suppresses identical warnings within a 60s window, deduplicated per process by default (you can set the option to `'process' | 'instance' | false`)
