### PR TITLE
fix(beasties): include resolved path and path options in stylesheet warning

### DIFF
--- a/packages/beasties/src/index.ts
+++ b/packages/beasties/src/index.ts
@@ -282,7 +282,10 @@ export default class Beasties {
       sheet = await this.readFile(filename)
     }
     catch {
-      this.logger.warn?.(`Unable to locate stylesheet: ${filename}`)
+      this.logger.warn?.(
+        `Unable to locate stylesheet ${href} (resolved to ${filename}, using path: ${JSON.stringify(outputPath)}, publicPath: ${JSON.stringify(publicPath)}). `
+        + `If this file is not part of your build output, add data-beasties-skip to its <link> to skip it.`,
+      )
     }
 
     return sheet

--- a/packages/beasties/test/warnings-stylesheet.test.ts
+++ b/packages/beasties/test/warnings-stylesheet.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import Beasties from '../src/index'
+import { resetMessageDeduplication } from '../src/util'
+
+function makeBeasties(options: Record<string, unknown> = {}, css = 'p { color: red }') {
+  const warn = vi.fn()
+  const debug = vi.fn()
+  const beasties = new Beasties({
+    reduceInlineStyles: false,
+    path: '/',
+    logger: { warn, debug },
+    ...options,
+  })
+  beasties.readFile = () => css
+  return { beasties, warn, debug }
+}
+
+describe('stylesheet resolution warning', () => {
+  beforeEach(() => {
+    resetMessageDeduplication()
+  })
+
+  it('reports the resolved path along with path and publicPath', async () => {
+    const { beasties, warn } = makeBeasties({ path: '/dist', publicPath: '/assets' })
+    beasties.readFile = () => Promise.reject(new Error('ENOENT'))
+
+    await beasties.process(`<html><head><link rel="stylesheet" href="/assets/style.css"></head><body></body></html>`)
+
+    const message = warn.mock.calls[0]![0] as string
+    expect(message).toContain('Unable to locate stylesheet /assets/style.css')
+    expect(message).toContain('path: "/dist"')
+    expect(message).toContain('publicPath: "/assets"')
+    expect(message).toContain('data-beasties-skip')
+  })
+
+  it('does not warn for links carrying data-beasties-skip', async () => {
+    const { beasties, warn } = makeBeasties()
+    beasties.readFile = () => Promise.reject(new Error('ENOENT'))
+
+    await beasties.process(`<html><head><link rel="stylesheet" href="/missing.css" data-beasties-skip></head><body></body></html>`)
+
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('Unable to locate stylesheet'))
+  })
+})


### PR DESCRIPTION
our default warning, `Unable to locate stylesheet: <path>`, gave no way to self-diagnose the issue.

the message now names the resolved path, and mentions `data-beasties-skip` as an escape hatch.

related: https://github.com/angular/angular-cli/issues/30986, https://github.com/angular/angular-cli/issues/20794 and https://github.com/angular/angular-cli/issues/27403