### PR TITLE
fix(beasties): only warn about selector errors that drop rules

### DIFF
--- a/packages/beasties/src/index.ts
+++ b/packages/beasties/src/index.ts
@@ -26,7 +26,7 @@ import { applyMarkedSelectors, markOnly, parseStylesheet, serializeStylesheet, v
 import { CRITTERS_DEPRECATION_WARNING, parseDirective } from './directives'
 import { createDocument, serializeDocument } from './dom'
 import { isSafeMediaValue } from './media'
-import { isAlwaysCriticalSelector, normalizeCssSelector } from './selectors'
+import { isAlwaysCriticalSelector, isUnevaluableSelectorError, normalizeCssSelector } from './selectors'
 import { REMOTE_URL_RE, resolveCssUrl, rewriteCssUrls } from './urls'
 import { createDeduplicatingLogger, createLogger, isSubpath } from './util'
 
@@ -559,7 +559,7 @@ export default class Beasties {
     // a string to search for font names (very loose)
     let criticalFonts = ''
 
-    const failedSelectors: string[] = []
+    const unparseableSelectors: string[] = []
 
     const criticalKeyframeNames = new Set()
 
@@ -662,7 +662,13 @@ export default class Beasties {
               return beastiesContainers.some(container => container.exists(sel))
             }
             catch (e) {
-              failedSelectors.push(`${sel} -> ${(e as Error).message || (e as Error).toString()}`)
+              const message = (e as Error).message || String(e)
+              if (isUnevaluableSelectorError(message)) {
+                this.logger.debug?.(`Cannot statically evaluate selector, excluding it from critical CSS: ${sel} (${message})`)
+              }
+              else {
+                unparseableSelectors.push(`${sel} (${message})`)
+              }
               return false
             }
           })
@@ -705,9 +711,10 @@ export default class Beasties {
       }),
     )
 
-    if (failedSelectors.length !== 0) {
+    if (unparseableSelectors.length !== 0) {
+      const single = unparseableSelectors.length === 1
       this.logger.warn?.(
-        `${failedSelectors.length} rules skipped due to selector errors:\n  ${failedSelectors.join('\n  ')}`,
+        `Could not parse ${single ? '1 selector' : `${unparseableSelectors.length} selectors`} in ${style.$$name || 'inline styles'}; ${single ? 'its rule was' : 'their rules were'} left out of the critical CSS but still ${single ? 'applies' : 'apply'} once the full stylesheet loads:\n  ${unparseableSelectors.join('\n  ')}`,
       )
     }
 

--- a/packages/beasties/src/selectors.ts
+++ b/packages/beasties/src/selectors.ts
@@ -3,6 +3,15 @@ const implicitUniversalPattern = /([>+~])\s*(?!\1)([>+~])/g
 const emptyCombinatorPattern = /([>+~])\s*(?=\1|$)/g
 const removeTrailingCommasPattern = /\(\s*,|,\s*\)/g
 const BEFORE_AFTER_PSEUDO_RE = /^::?(?:before|after)$/
+const UNEVALUABLE_SELECTOR_ERROR_RE = /^(?:unknown pseudo-class|pseudo-elements are not supported)/i
+
+/**
+ * Whether a selector matching error means the selector is valid CSS that cannot
+ * be evaluated statically (rather than a selector we failed to parse).
+ */
+export function isUnevaluableSelectorError(message: string): boolean {
+  return UNEVALUABLE_SELECTOR_ERROR_RE.test(message)
+}
 
 /**
  * Selectors that are considered critical regardless of whether they match an element in the document.

--- a/packages/beasties/test/warnings-selectors.test.ts
+++ b/packages/beasties/test/warnings-selectors.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import Beasties from '../src/index'
+import { isUnevaluableSelectorError } from '../src/selectors'
+import { resetMessageDeduplication } from '../src/util'
+
+const html = `<html><head><link rel="stylesheet" href="/style.css"></head><body><p>Hello</p></body></html>`
+
+function makeBeasties(options: Record<string, unknown> = {}, css = 'p { color: red }') {
+  const warn = vi.fn()
+  const debug = vi.fn()
+  const beasties = new Beasties({
+    reduceInlineStyles: false,
+    path: '/',
+    logger: { warn, debug },
+    ...options,
+  })
+  beasties.readFile = () => css
+  return { beasties, warn, debug }
+}
+
+describe('selector error warning', () => {
+  beforeEach(() => {
+    resetMessageDeduplication()
+  })
+
+  it('classifies selectors that cannot be statically evaluated', () => {
+    expect(isUnevaluableSelectorError('Unknown pseudo-class :_x')).toBe(true)
+    expect(isUnevaluableSelectorError('Pseudo-elements are not supported by css-select')).toBe(true)
+    expect(isUnevaluableSelectorError('Expected name, found ::')).toBe(false)
+  })
+
+  it('does not warn about selectors it cannot statically evaluate', async () => {
+    const { beasties, warn, debug } = makeBeasties({}, 'p:_x { color: red }')
+
+    await beasties.process(html)
+
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('selector'))
+    expect(debug).toHaveBeenCalledWith(expect.stringContaining('Cannot statically evaluate selector'))
+  })
+
+  it('states the consequence for selectors it cannot parse', async () => {
+    const { beasties, warn } = makeBeasties({}, 'p:: { color: red }')
+
+    await beasties.process(html)
+
+    expect(warn).toHaveBeenCalledWith(
+      'Could not parse 1 selector in /style.css; its rule was left out of the critical CSS but still applies once the full stylesheet loads:\n  p:: (Expected name, found ::)',
+    )
+  })
+
+  it('pluralises the message for multiple unparseable selectors', async () => {
+    const { beasties, warn } = makeBeasties({}, 'p:: { color: red }\nspan:: { color: green }')
+
+    await beasties.process(html)
+
+    const message = warn.mock.calls.map(call => call[0] as string).find(msg => msg.startsWith('Could not parse'))!
+    expect(message).toContain('Could not parse 2 selectors in /style.css; their rules were left out of the critical CSS but still apply once the full stylesheet loads:')
+  })
+})


### PR DESCRIPTION
`N rules skipped due to selector errors` usually describes a selector we deliberately cannot evaluate statically, rather than meaning inlining _failed_. so we now now log them at a debug level rather than warning.

genuine parse failures still warn, naming the stylesheet and stating that the rule still applies once the full stylesheet loads.

resolves https://github.com/angular/angular/issues/62370.