### PR TITLE
fix(beasties): dedupe font preload links across sheets and existing tags

### DIFF
--- a/packages/beasties/src/index.ts
+++ b/packages/beasties/src/index.ts
@@ -50,6 +50,7 @@ interface PreFetchedStylesheet {
 
 export default class Beasties {
   #selectorCache = new Map<string, string>()
+  #preloadedFonts = new WeakMap<HTMLDocument, Set<string>>()
   options: Options & Required<Pick<Options, 'logLevel' | 'path' | 'publicPath' | 'reduceInlineStyles' | 'pruneSource' | 'additionalStylesheets' | 'dedupeWarnings'>> & { allowRules: Array<string | RegExp> }
   logger: Logger
   fs?: typeof import('node:fs')
@@ -718,7 +719,7 @@ export default class Beasties {
       )
     }
 
-    const preloadedFonts = new Set<string>()
+    const preloadedFonts = this.getPreloadedFonts(document)
     // Second pass, using data picked up from the first
     walkStyleRulesWithReverseMirror(ast, astInverse, (rule) => {
       // remove any rules marked in the first pass
@@ -755,14 +756,17 @@ export default class Beasties {
             }
           }
 
-          if (src && shouldPreloadFonts && !preloadedFonts.has(src)) {
-            preloadedFonts.add(src)
-            const preload = document.createElement('link')
-            preload.setAttribute('rel', 'preload')
-            preload.setAttribute('as', 'font')
-            preload.setAttribute('crossorigin', 'anonymous')
-            preload.setAttribute('href', style.$$name ? resolveCssUrl(src.trim(), style.$$name) : src.trim())
-            document.head.appendChild(preload)
+          if (src && shouldPreloadFonts) {
+            const href = style.$$name ? resolveCssUrl(src.trim(), style.$$name) : src.trim()
+            if (!preloadedFonts.has(href)) {
+              preloadedFonts.add(href)
+              const preload = document.createElement('link')
+              preload.setAttribute('rel', 'preload')
+              preload.setAttribute('as', 'font')
+              preload.setAttribute('crossorigin', 'anonymous')
+              preload.setAttribute('href', href)
+              document.head.appendChild(preload)
+            }
           }
         }
 
@@ -826,6 +830,25 @@ export default class Beasties {
     this.logger.info?.(
       `\u001B[32mInlined ${formatSize(sheet.length)} (${percent}% of original ${formatSize(before.length)}) of ${name}${afterText}.\u001B[39m`,
     )
+  }
+
+  /**
+   * Font URLs already preloaded for a document, whether by beasties while
+   * processing an earlier stylesheet or by the document itself.
+   */
+  private getPreloadedFonts(document: HTMLDocument): Set<string> {
+    let preloaded = this.#preloadedFonts.get(document)
+    if (!preloaded) {
+      preloaded = new Set<string>()
+      for (const link of document.querySelectorAll('link[rel="preload"][as="font"]')) {
+        const href = link.getAttribute('href')
+        if (href) {
+          preloaded.add(href)
+        }
+      }
+      this.#preloadedFonts.set(document, preloaded)
+    }
+    return preloaded
   }
 
   private normalizeCssSelector(sel: string): string {

--- a/packages/beasties/src/runtime.ts
+++ b/packages/beasties/src/runtime.ts
@@ -830,6 +830,8 @@ function fingerprintTokens(tokens: DocumentTokens): string {
 const CSS_HREF_RE = /\.css(?:[?#]|$)/i
 const LINK_TAG_RE = /<link\b(?:[^>"']|"[^"]*"|'[^']*')*>/gi
 const REL_STYLESHEET_RE = /\brel\s*=\s*(?:"stylesheet"|'stylesheet'|stylesheet(?=[\s>]))/i
+const REL_PRELOAD_RE = /\brel\s*=\s*(?:"preload"|'preload'|preload(?=[\s>]))/i
+const AS_FONT_RE = /\bas\s*=\s*(?:"font"|'font'|font(?=[\s>]))/i
 
 const CSS_LOADER_PREAMBLE = 'function $loadcss(u,m,l){(l=document.createElement(\'link\')).rel=\'stylesheet\';l.href=u;document.head.appendChild(l)}'
 const CSS_LOADER_LAZY_PREAMBLE = CSS_LOADER_PREAMBLE.replace(
@@ -1067,11 +1069,18 @@ export function createProcessor(plans: Array<CompiledSheet | CompactPlan>, optio
     let deferredMedia = false
     const criticalParts: string[] = []
     const fontPreloads = new Set<string>()
+    const existingFontPreloads = new Set<string>()
     let isFirstSheet = true
 
     for (const match of html.matchAll(LINK_TAG_RE)) {
       const tag = match[0]
       if (!REL_STYLESHEET_RE.test(tag)) {
+        if (REL_PRELOAD_RE.test(tag) && AS_FONT_RE.test(tag)) {
+          const preloaded = getAttr(tag, 'href')
+          if (preloaded) {
+            existingFontPreloads.add(preloaded)
+          }
+        }
         continue
       }
       if (getAttr(tag, 'data-beasties-skip') !== null) {
@@ -1173,6 +1182,10 @@ export function createProcessor(plans: Array<CompiledSheet | CompactPlan>, optio
       }
 
       isFirstSheet = false
+    }
+
+    for (const preloaded of existingFontPreloads) {
+      fontPreloads.delete(preloaded)
     }
 
     const critical = criticalParts.join('')

--- a/packages/beasties/test/beasties.test.ts
+++ b/packages/beasties/test/beasties.test.ts
@@ -1264,6 +1264,60 @@ describe('beasties', () => {
     })
   })
 
+  describe('font preloads', () => {
+    const assets: Record<string, string> = {
+      '/one.css': '@font-face { font-family: MyFont; src: url(/fonts/my.woff2); }\nh1 { font-family: MyFont; }',
+      '/two.css': '@font-face { font-family: MyFont; src: url(/fonts/my.woff2); }\nh1 { font-family: MyFont; }',
+      '/nested/three.css': '@font-face { font-family: MyFont; src: url(my.woff2); }\nh1 { font-family: MyFont; }',
+    }
+
+    function makeBeasties(opts = {}) {
+      const b = new Beasties({ reduceInlineStyles: false, path: '/', preloadFonts: true, ...opts })
+      b.readFile = filename => assets[filename.replace(/^\w:/, '').replace(/\\/g, '/')]!
+      return b
+    }
+
+    it('should emit a single preload for a font shared by several stylesheets', async () => {
+      const result = await makeBeasties().process(trim`
+        <html>
+          <head>
+            <link rel="stylesheet" href="/one.css">
+            <link rel="stylesheet" href="/two.css">
+          </head>
+          <body><h1>Hello</h1></body>
+        </html>
+      `)
+      expect(result.match(/href="\/fonts\/my\.woff2"/g)).toHaveLength(1)
+    })
+
+    it('should not preload a font the document already preloads', async () => {
+      const result = await makeBeasties().process(trim`
+        <html>
+          <head>
+            <link rel="preload" as="font" crossorigin="anonymous" href="/fonts/my.woff2">
+            <link rel="stylesheet" href="/one.css">
+          </head>
+          <body><h1>Hello</h1></body>
+        </html>
+      `)
+      expect(result.match(/href="\/fonts\/my\.woff2"/g)).toHaveLength(1)
+    })
+
+    it('should preload fonts that resolve to different urls from the same relative src', async () => {
+      const result = await makeBeasties().process(trim`
+        <html>
+          <head>
+            <link rel="stylesheet" href="/one.css">
+            <link rel="stylesheet" href="/nested/three.css">
+          </head>
+          <body><h1>Hello</h1></body>
+        </html>
+      `)
+      expect(result).toContain('href="/fonts/my.woff2"')
+      expect(result).toContain('href="/nested/my.woff2"')
+    })
+  })
+
   describe('data-beasties-skip', () => {
     const assets: Record<string, string> = {
       '/styles.css': 'h1 { color: blue; }',

--- a/packages/beasties/test/compiled.test.ts
+++ b/packages/beasties/test/compiled.test.ts
@@ -732,6 +732,20 @@ describe('compiled beasties (compiler + runtime)', () => {
       expect(result).toContain('<link rel="preload" as="font" crossorigin="anonymous" href="/fonts/my.woff2">')
     })
 
+    it('does not preload a font the document already preloads', () => {
+      const css = trim`
+        h1 { font-family: MyFont; }
+        @font-face { font-family: MyFont; src: url(/fonts/my.woff2); }
+      `
+      const { process } = createProcessor([compileSheet(css, { href: 'style.css' })], { fonts: true })
+      const html = BASIC_HTML.replace(
+        '<link rel="stylesheet" href="/style.css">',
+        '<link rel="preload" as="font" crossorigin="anonymous" href="/fonts/my.woff2"><link rel="stylesheet" href="/style.css">',
+      )
+      const result = process(html)
+      expect(result.match(/href="\/fonts\/my\.woff2"/g)).toHaveLength(1)
+    })
+
     it('leaves html untouched when no sheets match', () => {
       const { process } = createProcessor([compileSheet('h1{color:blue}', { href: 'other.css' })])
       expect(process(BASIC_HTML)).toBe(BASIC_HTML)


### PR DESCRIPTION
previously, font preloads were deduplicated per stylesheet, but fonts in multiple stylesheets could trigger multiple preloads.

now we deduplicate per document, keyed on the resolved href

partly related: https://github.com/angular/angular-cli/issues/20206