### PR TITLE
feat(beasties): allow nonce option to be a function

### DIFF
--- a/packages/beasties/src/index.ts
+++ b/packages/beasties/src/index.ts
@@ -197,14 +197,20 @@ export default class Beasties {
       return
     }
     const script = document.createElement('script')
-    this.applyNonce(script)
+    this.applyNonce(document, script)
     script.textContent = DEFERRED_MEDIA_SCRIPT
     document.body.appendChild(script)
   }
 
-  private applyNonce(element: Node) {
-    if (this.options.nonce) {
-      element.setAttribute('nonce', this.options.nonce)
+  private nonceValue: string | undefined
+  private applyNonce(document: HTMLDocument, element: Node) {
+    this.nonceValue
+      ??= typeof this.options.nonce === 'function'
+        ? this.options.nonce(document)
+        : this.options.nonce
+
+    if (this.nonceValue) {
+      element.setAttribute('nonce', this.nonceValue)
     }
   }
 
@@ -319,7 +325,7 @@ export default class Beasties {
         }
         styleSheetsIncluded.push(cssFile)
         const style = document.createElement('style')
-        this.applyNonce(style)
+        this.applyNonce(document, style)
         style.$$external = true
         style.$$name = cssFile
         return this.getCssAsset(cssFile, style).then(sheet => [sheet, style] as const)
@@ -353,7 +359,7 @@ export default class Beasties {
 
     // dreate style element early so subclasses can use it in getCssAsset
     const style = document.createElement('style')
-    this.applyNonce(style)
+    this.applyNonce(document, style)
     style.$$external = true
 
     const sheet = await this.getCssAsset(href, style)
@@ -411,7 +417,7 @@ export default class Beasties {
     else {
       if (preloadMode === 'js' || preloadMode === 'js-lazy') {
         const script = document.createElement('script')
-        this.applyNonce(script)
+        this.applyNonce(document, script)
         script.setAttribute('data-href', href)
         script.setAttribute('data-media', media || 'all')
         const js = `${cssLoaderPreamble}$loadcss(document.currentScript.dataset.href,document.currentScript.dataset.media)`

--- a/packages/beasties/src/types.ts
+++ b/packages/beasties/src/types.ts
@@ -1,3 +1,4 @@
+import type { HTMLDocument } from './dom'
 import type { DedupeScope, Logger, LogLevel } from './util'
 
 /**
@@ -76,7 +77,7 @@ export interface Options {
   /**
    * CSP nonce to set on every `<style>` and `<script>` element beasties injects
    */
-  nonce?: string
+  nonce?: string | ((document: HTMLDocument) => string | undefined)
   /**
    * Inline critical font-face rules _(default: `false`)_
    */

--- a/packages/beasties/test/csp.test.ts
+++ b/packages/beasties/test/csp.test.ts
@@ -1,6 +1,7 @@
+import type { HTMLDocument } from '../src/dom'
 import { DomUtils, parseDocument } from 'htmlparser2'
-import { describe, expect, it } from 'vitest'
 
+import { describe, expect, it, vi } from 'vitest'
 import { compileSheet } from '../src/compiler'
 import Beasties from '../src/index'
 import { createProcessor } from '../src/runtime'
@@ -54,6 +55,53 @@ describe('nonce (classic)', () => {
     const result = await classic({ nonce: 'a"><b>', preload: false }).process(html())
     expect(result).toContain('<style nonce="a&quot;><b>">')
   })
+
+  it('should set the nonce returned by a function on the inlined style', async () => {
+    const nonce = vi.fn(() => 'abc123')
+    const result = await classic({ nonce, preload: false }).process(html())
+    expect(result).toContain('<style nonce="abc123">h1{color:blue}</style>')
+    expect(nonce).toHaveBeenCalledOnce()
+  })
+
+  it('should pass the document to the nonce function', async () => {
+    let receivedDoc: HTMLDocument | undefined
+    const result = await classic({
+      nonce: (doc) => {
+        receivedDoc = doc
+        return doc.querySelector('meta[name="csp-nonce"]')?.getAttribute('content')
+      },
+      preload: false,
+    }).process(
+      '<html><head><meta name="csp-nonce" content="meta-nonce"><link rel="stylesheet" href="/style.css"></head><body><h1>Hello World!</h1></body></html>',
+    )
+    expect(receivedDoc).toBeDefined()
+    expect(result).toContain('<style nonce="meta-nonce">h1{color:blue}</style>')
+  })
+
+  it('should not set a nonce when the nonce function returns undefined', async () => {
+    const result = await classic({ nonce: () => undefined, preload: false }).process(html())
+    expect(result).toContain('<style>h1{color:blue}</style>')
+  })
+
+  it('should set the function-provided nonce on additional stylesheets', async () => {
+    const beasties = classic({ nonce: () => 'abc123', preload: false, additionalStylesheets: ['/extra.css'] })
+    const result = await beasties.process(html(''))
+    expect(result).toContain('<style nonce="abc123">h1{color:blue}</style>')
+  })
+
+  it('should set the function-provided nonce on the "js" loader script', async () => {
+    const result = await classic({ nonce: () => 'abc123', preload: 'js' }).process(html())
+    expect(result).toContain('<script nonce="abc123" data-href="/style.css" data-media="all">')
+  })
+
+  it('should evaluate the nonce function only once per document', async () => {
+    const nonce = vi.fn(() => 'abc123')
+    const beasties = classic({ nonce, preload: 'js' })
+    const result = await beasties.process(html())
+    expect(result).toContain('<style nonce="abc123">')
+    expect(result).toContain('<script nonce="abc123"')
+    expect(nonce).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('nonce (compiled)', () => {
@@ -91,6 +139,11 @@ describe('"media-script" preload mode (classic)', () => {
 
   it('should set the nonce on the script', async () => {
     const result = await classic({ preload: 'media-script', nonce: 'abc123' }).process(html())
+    expect(result).toContain(`<script nonce="abc123">${DEFERRED_SCRIPT}</script>`)
+  })
+
+  it('should set the function-provided nonce on the script', async () => {
+    const result = await classic({ preload: 'media-script', nonce: () => 'abc123' }).process(html())
     expect(result).toContain(`<script nonce="abc123">${DEFERRED_SCRIPT}</script>`)
   })
 


### PR DESCRIPTION
Allow the `nonce` option to accept a function `(document: HTMLDocument) => string | undefined`.

This enables dynamically resolving CSP nonces from the document being processed (e.g. from a `<meta name=csp-nonce>` element or other document metadata) and caches the resolved value for injected style and script elements.