### PR TITLE
fix(beasties): update nonce type definition to allow a function

### DIFF
--- a/packages/beasties/src/index.d.ts
+++ b/packages/beasties/src/index.d.ts
@@ -58,7 +58,7 @@ export interface Options {
   additionalStylesheets?: string[]
   preload?: 'body' | 'media' | 'media-script' | 'swap' | 'swap-high' | 'swap-low' | 'js' | 'js-lazy'
   noscriptFallback?: boolean
-  nonce?: string
+  nonce?: string | ((document: HTMLDocument) => string | undefined)
   inlineFonts?: boolean
   preloadFonts?: boolean
   allowRules?: Array<string | RegExp>


### PR DESCRIPTION
Follow-up to #415.

Update `Options.nonce` type definition in `packages/beasties/src/index.d.ts` to allow `((document: HTMLDocument) => string | undefined)`, keeping it in sync with `src/types.ts`.