### PR TITLE
feat(beasties): add per-request `nonce` option for `beasties/runtime`

### DIFF
--- a/packages/beasties/README.md
+++ b/packages/beasties/README.md
@@ -130,7 +130,7 @@ All optional. Pass them to `new Beasties({ ... })`.
 - `allowRules` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)<[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [RegExp](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp)>** Always include rules matching these selectors or patterns in the critical CSS, regardless of whether they match elements in the document. _(default: `[]`)_
 - `preload` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Which [preload strategy](#preloadstrategy) to use
 - `noscriptFallback` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Add `<noscript>` fallback to JS-based strategies
-- `nonce` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** CSP nonce to set on every `<style>` and `<script>` element beasties injects
+- `nonce` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function)** CSP nonce to set on every `<style>` and `<script>` element beasties injects, or a function called once per document to derive it
 - `inlineFonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Inline critical font-face rules _(default: `false`)_
 - `preloadFonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Preloads critical fonts _(default: `true`)_
 - `fonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Shorthand for setting `inlineFonts` + `preloadFonts`\* Values:
@@ -297,6 +297,15 @@ const beasties = new Beasties({
 })
 ```
 
+A nonce must be unique per response, so if you reuse one instance across requests, pass a function instead of a string. It is called once per document:
+
+```js
+const beasties = new Beasties({
+  preload: 'media-script',
+  nonce: document => readNonceFrom(document),
+})
+```
+
 Deferred links are left as `media="print"` with the real media value in `data-beasties-media`, and a single script restores them:
 
 ```html
@@ -307,6 +316,67 @@ Deferred links are left as `media="print"` with the real media value in `data-be
 ```
 
 Exactly one script is emitted per document and its body never varies, so if you cannot supply a nonce you can allow it with a static `script-src` hash instead.
+
+### Compiler and runtime
+
+Using Beasties per request has two problems: its dependencies are ~1.8 MB of bundle, and every response re-parses the HTML into a DOM and the stylesheets into PostCSS.
+
+But after a build the CSS is usually static, so it can be processed _in advance_. Two subpath exports split the work: `beasties/compiler` runs at build time and keeps PostCSS and css-what, `beasties/runtime` runs per request with no dependencies at all.
+
+|  | classic `process()` | `beasties/runtime` |
+| --- | --- | --- |
+| 13 kB CSS, 21 kB HTML | 3.0ms | 0.4ms |
+| 413 kB CSS, 21 kB HTML | 36.1ms | 1.2ms |
+| runtime dependencies | 9 (~1.8 MB unpacked) | none (~27 kB) |
+
+**1. The compiler turns a stylesheet into a 'plan'**
+
+```js
+import { compileSheet, encodePlan } from 'beasties/compiler'
+
+const plan = encodePlan(compileSheet(css, { href: '/style.css' }))
+```
+
+Rules come out pre-minified, selectors normalised, comment markers and `allowRules` resolved, `url()` values rebased, and font and keyframe dependencies extracted. `href` is what matches a plan to a `<link>` tag later, so a plan compiled without one never matches and the document passes through untouched.
+
+`encodePlan` gives you JSON, so plans can be embedded in a server bundle. They are stored compactly, and utility CSS pools well enough to come out smaller than the stylesheet it describes:
+
+| stylesheet | encoded plan |
+| --- | --- |
+| 13 kB fixture | 15 kB (1.15x) |
+| 413 kB utility-scale | 198 kB (0.48x) |
+
+Decoding costs about 9ms once at startup for a 300 kB plan.
+
+**2. The processor makes a single pass over the HTML**
+
+```js
+import { createProcessor } from 'beasties/runtime'
+
+const processor = createProcessor(plans, { preload: 'media-script' })
+
+const html = processor.process(rendered, { nonce: requestNonce })
+```
+
+Tags, classes, ids and attributes are collected, then critical CSS is spliced in as a string rather than round-tripping a DOM. `processor.extract(html)` returns the critical CSS and font preloads without rewriting the document, if you would rather place them yourself.
+
+Create the processor once and reuse it. Anything that varies per response, like a CSP nonce, belongs in the `process()` call instead.
+
+Without a DOM, selectors do not apply with 100% accuracy. Simple selectors (a single class, id, tag, or attribute presence) are decided by presence in those token sets; combinators, compound selectors like `.a.b`, and attribute values compile to a small match program that runs during the same scan, using the open-element stack for ancestor and sibling context. Set `exact: false` at compile time to fall back to token presence only, which over-inlines combinator selectors but is cheaper and safer.
+
+Options split roughly along the same line:
+
+| option | where |
+| --- | --- |
+| `allowRules`, `safeParser`, `exact`, comment markers | build-time |
+| `preload` (all strategies), `noscriptFallback`, `keyframes`, `fonts`, `inlineFonts`, `preloadFonts`, `inlineThreshold`, `minimumExternalSize`, `cache`, `nonce` | runtime |
+| `path`, `publicPath`, `external`, `remote`, `additionalStylesheets` | configurable |
+| `pruneSource`, `reduceInlineStyles` | not supported |
+
+Critical CSS is cached per document shape, keyed on a fingerprint of the scanned tokens. Enable `cache` only for large stylesheets - with smaller ones the scan is the expensive piece.
+
+> [!NOTE]
+> `minimumExternalSize` is measured against the rules that weren't inlined, not against the stylesheet. It and `inlineThreshold` both inline the stylesheet in full and remove its `<link>` entirely.
 
 ### Logger
 

--- a/packages/beasties/src/index.ts
+++ b/packages/beasties/src/index.ts
@@ -202,15 +202,20 @@ export default class Beasties {
     document.body.appendChild(script)
   }
 
-  private nonceValue: string | undefined
+  // a nonce must not be shared between responses, so it is resolved once per
+  // document rather than once per instance
+  #nonces = new WeakMap<HTMLDocument, string | undefined>()
   private applyNonce(document: HTMLDocument, element: Node) {
-    this.nonceValue
-      ??= typeof this.options.nonce === 'function'
-        ? this.options.nonce(document)
-        : this.options.nonce
+    if (!this.#nonces.has(document)) {
+      this.#nonces.set(
+        document,
+        typeof this.options.nonce === 'function' ? this.options.nonce(document) : this.options.nonce,
+      )
+    }
 
-    if (this.nonceValue) {
-      element.setAttribute('nonce', this.nonceValue)
+    const nonce = this.#nonces.get(document)
+    if (nonce) {
+      element.setAttribute('nonce', nonce)
     }
   }
 

--- a/packages/beasties/src/runtime.ts
+++ b/packages/beasties/src/runtime.ts
@@ -777,7 +777,10 @@ export interface ProcessorOptions extends RuntimeOptions {
    */
   noscriptFallback?: boolean
   /**
-   * CSP nonce to set on every `<style>` and `<script>` element beasties injects
+   * CSP nonce to set on every `<style>` and `<script>` element beasties
+   * injects. A processor is typically long-lived and a nonce must be unique
+   * per response, so pass it to `process()` instead unless it is genuinely
+   * constant for the lifetime of the processor.
    */
   nonce?: string
   /**
@@ -961,8 +964,16 @@ function applyEdits(html: string, edits: Edit[]): string {
  * Create a `process(html)` function which inlines critical CSS from the
  * compiled sheets into rendered HTML.
  */
+export interface ProcessOptions {
+  /**
+   * CSP nonce to set on every `<style>` and `<script>` element injected into
+   * this document, overriding any nonce given to `createProcessor`.
+   */
+  nonce?: string
+}
+
 export function createProcessor(plans: Array<CompiledSheet | CompactPlan>, options: ProcessorOptions = {}): {
-  process: (html: string) => string
+  process: (html: string, processOptions?: ProcessOptions) => string
   extract: (html: string) => CriticalResult
 } {
   const sheets = plans.map(plan => (isCompactPlan(plan) ? decodePlan(plan) : plan))
@@ -974,7 +985,6 @@ export function createProcessor(plans: Array<CompiledSheet | CompactPlan>, optio
   // the inverse is only needed to compare against `minimumExternalSize`
   const renderOptions = { ...options, inverse: !!options.minimumExternalSize }
   const fullCssCache = new Map<CompiledSheet, string>()
-  const nonceAttr = options.nonce ? ` nonce="${escapeAttr(options.nonce)}"` : ''
 
   function fullCss(sheet: CompiledSheet): string {
     let css = fullCssCache.get(sheet)
@@ -1058,10 +1068,12 @@ export function createProcessor(plans: Array<CompiledSheet | CompactPlan>, optio
     return { css: css.join(''), fontPreloads }
   }
 
-  function process(html: string): string {
+  function process(html: string, processOptions?: ProcessOptions): string {
     const tokens = scanHtml(html, programs)
     const key = cache ? fingerprintTokens(tokens) : undefined
     const strategy = options.preload
+    const nonce = processOptions?.nonce ?? options.nonce
+    const nonceAttr = nonce ? ` nonce="${escapeAttr(nonce)}"` : ''
 
     let firstLinkIndex = -1
     const edits: Edit[] = []

--- a/packages/beasties/test/csp.test.ts
+++ b/packages/beasties/test/csp.test.ts
@@ -94,6 +94,15 @@ describe('nonce (classic)', () => {
     expect(result).toContain('<script nonce="abc123" data-href="/style.css" data-media="all">')
   })
 
+  it('should evaluate the nonce function for each document', async () => {
+    const nonce = vi.fn((document: HTMLDocument) => document.querySelector('meta[name="csp-nonce"]')?.getAttribute('content'))
+    const beasties = classic({ nonce, preload: false })
+    const withNonce = (value: string) => `<html><head><meta name="csp-nonce" content="${value}"><link rel="stylesheet" href="/style.css"></head><body><h1>Hello World!</h1></body></html>`
+    expect(await beasties.process(withNonce('request-1'))).toContain('<style nonce="request-1">')
+    expect(await beasties.process(withNonce('request-2'))).toContain('<style nonce="request-2">')
+    expect(nonce).toHaveBeenCalledTimes(2)
+  })
+
   it('should evaluate the nonce function only once per document', async () => {
     const nonce = vi.fn(() => 'abc123')
     const beasties = classic({ nonce, preload: 'js' })

--- a/packages/beasties/test/csp.test.ts
+++ b/packages/beasties/test/csp.test.ts
@@ -119,6 +119,29 @@ describe('nonce (compiled)', () => {
     const result = compiled({ nonce: 'a"><b>', preload: false }).process(html())
     expect(result).toContain('<style nonce="a&quot;><b>">')
   })
+
+  it('should set a per-document nonce passed to process', () => {
+    const processor = compiled({ preload: 'js' })
+    expect(processor.process(html(), { nonce: 'first' })).toContain('<style nonce="first">h1{color:blue}</style>')
+    expect(processor.process(html(), { nonce: 'second' })).toContain('<style nonce="second">h1{color:blue}</style>')
+    expect(processor.process(html(), { nonce: 'second' })).toContain('<script nonce="second" data-href="/style.css"')
+  })
+
+  it('should let a per-document nonce override the processor nonce', () => {
+    const result = compiled({ nonce: 'from-options', preload: false }).process(html(), { nonce: 'from-document' })
+    expect(result).toContain('<style nonce="from-document">h1{color:blue}</style>')
+  })
+
+  it('should fall back to the processor nonce when none is passed', () => {
+    const result = compiled({ nonce: 'from-options', preload: false }).process(html(), {})
+    expect(result).toContain('<style nonce="from-options">h1{color:blue}</style>')
+  })
+
+  it('should not reuse a cached document nonce', () => {
+    const processor = compiled({ nonce: 'from-options', preload: false })
+    processor.process(html(), { nonce: 'first' })
+    expect(processor.process(html())).toContain('<style nonce="from-options">h1{color:blue}</style>')
+  })
 })
 
 describe('"media-script" preload mode (classic)', () => {
@@ -196,6 +219,11 @@ describe('"media-script" preload mode (compiled)', () => {
 
   it('should set the nonce on the script', () => {
     const result = compiled({ preload: 'media-script', nonce: 'abc123' }).process(html())
+    expect(result).toContain(`<script nonce="abc123">${DEFERRED_SCRIPT}</script>`)
+  })
+
+  it('should set a per-document nonce on the script', () => {
+    const result = compiled({ preload: 'media-script' }).process(html(), { nonce: 'abc123' })
     expect(result).toContain(`<script nonce="abc123">${DEFERRED_SCRIPT}</script>`)
   })
 


### PR DESCRIPTION
this adds support for per-request nonce to `beasties/runtime` - an oversight when adding https://github.com/danielroe/beasties/pull/410...

also added some missing documentation, and fixed the classic beasties entry to compute a nonce 1x per document, rather than per instance