### PR TITLE
fix(beasties): bias plan pool refs so index 0 isn't read as absent

### DIFF
--- a/packages/beasties/src/plan-decode.ts
+++ b/packages/beasties/src/plan-decode.ts
@@ -20,7 +20,7 @@ import {
 
 export function decodePlan(plan: CompactPlan): CompiledSheet {
   const [, href, size, pool, wraps, rules] = plan
-  const deref = (value: PooledString): string => (typeof value === 'number' ? pool[value]! : value)
+  const deref = (value: PooledString): string => (typeof value === 'number' ? pool[value - 1]! : value)
   const derefAll = (values: PooledString[]): string[] => values.map(deref)
   const wrapChains = wraps.map(derefAll)
 

--- a/packages/beasties/src/plan-encode.ts
+++ b/packages/beasties/src/plan-encode.ts
@@ -37,12 +37,13 @@ class StringPool {
   finalize(): void {
     for (const [value, count] of this.#counts) {
       if (count > 1) {
-        this.#indices.set(value, this.strings.length)
         this.strings.push(value)
+        this.#indices.set(value, this.strings.length)
       }
     }
   }
 
+  /** A pooled string's one-based index, or the string itself when it isn't pooled */
   ref(value: string): PooledString {
     return this.#indices.get(value) ?? value
   }

--- a/packages/beasties/src/plan.ts
+++ b/packages/beasties/src/plan.ts
@@ -12,7 +12,11 @@
 
 import type { AttrTest } from './compiler'
 
-/** A string, or an index into the plan's string pool */
+/**
+ * A string, or a one-based index into the plan's string pool. References are
+ * biased by one so that `0` is free to mean "field absent" in the slots typed
+ * `PooledString | 0`.
+ */
 export type PooledString = string | number
 
 export type CompactPlan = [

--- a/packages/beasties/test/plan.test.ts
+++ b/packages/beasties/test/plan.test.ts
@@ -126,6 +126,24 @@ describe('compact plan format', () => {
       expect(roundTrip(sheet).warnings).toEqual([])
     })
 
+    it('keeps fields whose pooled string lands at pool index 0', () => {
+      const css = `
+        @font-face { font-family: poppins; src: url(/poppins.woff2) }
+        .a poppins { color: red }
+        .b poppins { color: blue }
+        [data-font="poppins"] { color: teal }
+        [data-label="poppins"] { color: olive }
+      `
+      const sheet = compileSheet(css, { href: 'style.css' })
+      const plan = encodePlan(sheet)
+      expect(plan[3][0]).toBe('poppins')
+
+      const decoded = roundTrip(sheet)
+      expect(decoded.rules[0]!.fontFace).toEqual({ family: 'poppins', src: '/poppins.woff2' })
+      expect(decoded.rules[1]!.match).toEqual([{ program: { combinators: [' '], compounds: [{ classes: ['a'] }, { tag: 'poppins' }] } }])
+      expect(decoded.rules[3]!.match).toEqual([{ program: { combinators: [], compounds: [{ attrs: [{ name: 'data-font', action: 'equals', value: 'poppins' }] }] } }])
+    })
+
     it('keeps href and source size', () => {
       const sheet = compileSheet('h1 { color: blue }', { href: '_nuxt/entry.abc.css' })
       const decoded = roundTrip(sheet)


### PR DESCRIPTION
the compact plan uses `0` to indicate _absence_ for slots typed `PooledString | 0`, but `ref()` returned the raw pool index - which could be `0` for single-item arrays

this affected `fontFace.family` and `fontFace.src`, a compound's `tag` and an attribute's `value`

now, we bias pool references by one, so `0` can remain a sentinel for absence