### PR TITLE
fix(beasties): improve font inlining behaviour

### DIFF
--- a/packages/beasties/README.md
+++ b/packages/beasties/README.md
@@ -133,6 +133,8 @@ All optional. Pass them to `new Beasties({ ... })`.
 - `nonce` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) | [Function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function)** CSP nonce to set on every `<style>` and `<script>` element beasties injects, or a function called once per document to derive it
 - `inlineFonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Inline critical font-face rules _(default: `false`)_
 - `preloadFonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Preloads critical fonts _(default: `true`)_
+
+  A font is critical when the critical CSS declares its family, and, for a face with a `unicode-range`, when the document's text contains a character that face covers. Faces of unused families and unused subsets are neither inlined nor preloaded; they still load with the deferred stylesheet.
 - `fonts` **[Boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Shorthand for setting `inlineFonts` + `preloadFonts`\* Values:
   - `true` to inline critical font-face rules and preload the fonts
   - `false` to don't inline any font-face rules and don't preload fonts

--- a/packages/beasties/src/compiler.ts
+++ b/packages/beasties/src/compiler.ts
@@ -12,13 +12,14 @@ import type { AtRule, Container, Rule } from 'postcss'
 import { parse as parseSelectorAst } from 'css-what'
 import { parseStylesheet, serializeStylesheet } from './css'
 import { CRITTERS_DEPRECATION_WARNING, parseDirective } from './directives'
+import { parseFontFamilies } from './fonts'
 import { isAlwaysCriticalSelector, normalizeCssSelector } from './selectors'
 import { resolveCssUrl, rewriteCssUrls } from './urls'
 
 export type { CompactPlan } from './plan'
 export { encodePlan } from './plan-encode'
 
-const FONT_FAMILY_RE = /\bfont(?:-family)?\b/i
+const FONT_PROP_RE = /^font(?:-family)?$/i
 const WHITESPACE_RE = /\s+/
 // eslint-disable-next-line regexp/no-super-linear-backtracking,regexp/no-misleading-capturing-group
 const URL_RE = /url\s*\(\s*(['"]?)(.+?)\1\s*\)/
@@ -91,7 +92,7 @@ export interface CompiledRule {
   always?: true
   /** Chain of enclosing at-rule wrappers, each ending with `{` */
   wrap?: string[]
-  /** Font-family values referenced by this rule's declarations */
+  /** Normalized font families referenced by this rule's declarations */
   fontsUsed?: string[]
   /** Animation names referenced by this rule's declarations */
   keyframesUsed?: string[]
@@ -457,8 +458,10 @@ function collectDependencies(rule: Rule, compiled: CompiledRule) {
     if (!('prop' in decl)) {
       continue
     }
-    if (FONT_FAMILY_RE.test(decl.prop)) {
-      (compiled.fontsUsed ??= []).push(decl.value)
+    if (FONT_PROP_RE.test(decl.prop)) {
+      for (const family of parseFontFamilies(decl.prop, decl.value)) {
+        (compiled.fontsUsed ??= []).push(family)
+      }
     }
     if (decl.prop === 'animation' || decl.prop === 'animation-name') {
       for (const name of decl.value.split(WHITESPACE_RE)) {

--- a/packages/beasties/src/compiler.ts
+++ b/packages/beasties/src/compiler.ts
@@ -12,7 +12,7 @@ import type { AtRule, Container, Rule } from 'postcss'
 import { parse as parseSelectorAst } from 'css-what'
 import { parseStylesheet, serializeStylesheet } from './css'
 import { CRITTERS_DEPRECATION_WARNING, parseDirective } from './directives'
-import { parseFontFamilies } from './fonts'
+import { parseFontFamilies, parseUnicodeRanges } from './fonts'
 import { isAlwaysCriticalSelector, normalizeCssSelector } from './selectors'
 import { resolveCssUrl, rewriteCssUrls } from './urls'
 
@@ -97,7 +97,12 @@ export interface CompiledRule {
   /** Animation names referenced by this rule's declarations */
   keyframesUsed?: string[]
   /** This rule is an @font-face */
-  fontFace?: { family?: string, src?: string }
+  fontFace?: {
+    family?: string
+    src?: string
+    /** `unicode-range` as flattened `[start, end, ...]` codepoint pairs */
+    ranges?: number[]
+  }
   /** This rule is a @keyframes block with this name */
   keyframes?: string
 }
@@ -287,6 +292,7 @@ function compileAtRule(rule: AtRule, wrap: string[], sheet: CompiledSheet, state
   if (name === 'font-face') {
     let family: string | undefined
     let src: string | undefined
+    let ranges: number[] | undefined
     for (const decl of rule.nodes ?? []) {
       if (!('prop' in decl))
         continue
@@ -296,10 +302,13 @@ function compileAtRule(rule: AtRule, wrap: string[], sheet: CompiledSheet, state
       else if (decl.prop === 'font-family') {
         family = decl.value
       }
+      else if (decl.prop === 'unicode-range') {
+        ranges = parseUnicodeRanges(decl.value)
+      }
     }
     sheet.rules.push(withWrap({
       css: rebase(serializeStylesheet(rule, { compress: true })),
-      fontFace: { family, src: src && options.href ? resolveCssUrl(src.trim(), options.href) : src },
+      fontFace: { family, src: src && options.href ? resolveCssUrl(src.trim(), options.href) : src, ranges },
     }, wrap))
     return
   }

--- a/packages/beasties/src/fonts.ts
+++ b/packages/beasties/src/fonts.ts
@@ -1,0 +1,111 @@
+/**
+ * Font family parsing shared by the compiler, the runtime and the DOM-based
+ * pipeline, so that families collected from `font-family` / `font`
+ * declarations can be compared with `@font-face` families regardless of
+ * quoting, escaping or case.
+ */
+
+const CSS_WIDE_KEYWORDS = new Set(['inherit', 'initial', 'unset', 'revert', 'revert-layer'])
+const HEX_ESCAPE_RE = /\\([0-9a-f]{1,6})[\t\n\f\r ]?/gi
+const CHAR_ESCAPE_RE = /\\(.)/g
+const WHITESPACE_RE = /\s+/g
+// a `font` shorthand's family list starts after the font-size, which may carry
+// a `/line-height`. A size is a length or percentage, an absolute/relative size
+// keyword, or a function; unitless numbers before it are weights, not sizes.
+const FONT_SIZE_RE = /^(?:[+-]?(?:\d+|\d*\.\d+)(?:[a-z]+|%)|calc\(|var\()/i
+const FONT_SIZE_KEYWORDS = new Set(['xx-small', 'x-small', 'small', 'medium', 'large', 'x-large', 'xx-large', 'xxx-large', 'smaller', 'larger'])
+
+/** Case-fold, unquote and unescape a single family name for comparison */
+export function normalizeFontFamily(family: string): string {
+  let value = family.trim()
+  const quote = value[0]
+  if ((quote === '"' || quote === '\'') && value.endsWith(quote) && value.length > 1) {
+    value = value.slice(1, -1)
+  }
+  value = value
+    .replace(HEX_ESCAPE_RE, (_, hex: string) => String.fromCodePoint(Number.parseInt(hex, 16)))
+    .replace(CHAR_ESCAPE_RE, '$1')
+    .replace(WHITESPACE_RE, ' ')
+    .trim()
+  return value.toLowerCase()
+}
+
+/**
+ * Extract normalized family names from the value of a `font-family` or `font`
+ * declaration. CSS-wide keywords and system font shorthands yield no families.
+ */
+export function parseFontFamilies(prop: string, value: string): string[] {
+  const isShorthand = prop.toLowerCase() === 'font'
+  const segments = splitTopLevel(value)
+  if (isShorthand) {
+    const first = segments[0]
+    if (first === undefined) {
+      return []
+    }
+    const tail = shorthandFamily(first)
+    if (tail === undefined) {
+      return []
+    }
+    segments[0] = tail
+  }
+
+  const families: string[] = []
+  for (const segment of segments) {
+    const family = normalizeFontFamily(segment)
+    if (family && !CSS_WIDE_KEYWORDS.has(family)) {
+      families.push(family)
+    }
+  }
+  return families
+}
+
+/**
+ * The family portion of a `font` shorthand's first comma-separated segment, or
+ * `undefined` when the segment has no font-size and so declares no family
+ * (`font: inherit`, `font: menu`).
+ */
+function shorthandFamily(segment: string): string | undefined {
+  const tokens = segment.trim().replace(/\s*\/\s*/g, '/').split(/\s+/)
+  for (let i = 0; i < tokens.length; i++) {
+    const size = tokens[i]!.split('/')[0]!
+    if (FONT_SIZE_RE.test(size) || FONT_SIZE_KEYWORDS.has(size.toLowerCase())) {
+      return tokens.slice(i + 1).join(' ')
+    }
+  }
+  return undefined
+}
+
+/** Split a family list on top-level commas, ignoring those inside quotes or parens */
+function splitTopLevel(value: string): string[] {
+  const segments: string[] = []
+  let start = 0
+  let depth = 0
+  let quote: string | undefined
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i]!
+    if (quote) {
+      if (char === '\\') {
+        i++
+      }
+      else if (char === quote) {
+        quote = undefined
+      }
+      continue
+    }
+    if (char === '"' || char === '\'') {
+      quote = char
+    }
+    else if (char === '(') {
+      depth++
+    }
+    else if (char === ')') {
+      depth = Math.max(0, depth - 1)
+    }
+    else if (char === ',' && depth === 0) {
+      segments.push(value.slice(start, i))
+      start = i + 1
+    }
+  }
+  segments.push(value.slice(start))
+  return segments
+}

--- a/packages/beasties/src/fonts.ts
+++ b/packages/beasties/src/fonts.ts
@@ -15,6 +15,157 @@ const WHITESPACE_RE = /\s+/g
 const FONT_SIZE_RE = /^(?:[+-]?(?:\d+|\d*\.\d+)(?:[a-z]+|%)|calc\(|var\()/i
 const FONT_SIZE_KEYWORDS = new Set(['xx-small', 'x-small', 'small', 'medium', 'large', 'x-large', 'xx-large', 'xxx-large', 'smaller', 'larger'])
 
+const UNICODE_RANGE_RE = /^u\+([0-9a-f]{1,6})(?:-([0-9a-f]{1,6}))?$/i
+const UNICODE_WILDCARD_RE = /^u\+([0-9a-f]{0,5})(\?{1,6})$/i
+
+/**
+ * Parse a `unicode-range` descriptor into flattened `[start, end, ...]`
+ * codepoint pairs, or `undefined` if any part of it isn't understood, in which
+ * case callers must treat the face as covering everything.
+ */
+export function parseUnicodeRanges(value: string): number[] | undefined {
+  const ranges: number[] = []
+  for (const token of splitTopLevel(value)) {
+    const part = token.trim()
+    if (!part) {
+      continue
+    }
+    const wildcard = UNICODE_WILDCARD_RE.exec(part)
+    if (wildcard) {
+      const prefix = wildcard[1]!
+      const digits = wildcard[2]!.length
+      if (prefix.length + digits > 6) {
+        return undefined
+      }
+      ranges.push(
+        Number.parseInt(prefix + '0'.repeat(digits), 16),
+        Number.parseInt(prefix + 'f'.repeat(digits), 16),
+      )
+      continue
+    }
+    const range = UNICODE_RANGE_RE.exec(part)
+    if (!range) {
+      return undefined
+    }
+    const start = Number.parseInt(range[1]!, 16)
+    const end = range[2] === undefined ? start : Number.parseInt(range[2], 16)
+    if (end < start) {
+      return undefined
+    }
+    ranges.push(start, end)
+  }
+  return ranges.length > 0 ? ranges : undefined
+}
+
+/**
+ * Whether any of a document's codepoints falls inside a face's `unicode-range`.
+ * Unknown ranges or unknown document text count as a match, so a face is only
+ * excluded when its subset is provably unused.
+ */
+export function unicodeRangeUsed(ranges: number[] | undefined, chars: Set<number> | undefined): boolean {
+  if (!ranges || !chars) {
+    return true
+  }
+  for (const codepoint of chars) {
+    for (let i = 0; i < ranges.length; i += 2) {
+      if (codepoint >= ranges[i]! && codepoint <= ranges[i + 1]!) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+const ENTITY_RE = /&(#x[0-9a-f]+|#\d+|[a-z][a-z0-9]*);/iy
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  apos: '\'',
+  gt: '>',
+  lt: '<',
+  nbsp: '\u00A0',
+  quot: '"',
+}
+
+/**
+ * Codepoints seen in a document's text. BMP codepoints are marked in a flat
+ * byte table because collecting them character by character is hot enough for
+ * `Set` operations to show up in scan timings.
+ */
+export interface TextCodepoints {
+  bmp: Uint8Array
+  astral: Set<number>
+  /** Whether all of the text could be decoded */
+  complete: boolean
+}
+
+export function createTextCodepoints(): TextCodepoints {
+  return { bmp: new Uint8Array(0x10000), astral: new Set(), complete: true }
+}
+
+/** Materialize collected codepoints, or `undefined` if some text was undecodable */
+export function toCodepointSet(text: TextCodepoints): Set<number> | undefined {
+  if (!text.complete) {
+    return undefined
+  }
+  const chars = new Set<number>(text.astral)
+  for (let codepoint = 0; codepoint < text.bmp.length; codepoint++) {
+    if (text.bmp[codepoint]) {
+      chars.add(codepoint)
+    }
+  }
+  return chars
+}
+
+/**
+ * Add the codepoints of a run of (possibly entity-encoded) HTML text. An
+ * entity that can't be decoded clears `complete`, since the document then
+ * contains characters we can't account for.
+ */
+export function addTextCodepoints(text: string, into: TextCodepoints): void {
+  const { bmp } = into
+  for (let index = 0; index < text.length; index++) {
+    const code = text.charCodeAt(index)
+    if (code === 0x26 /* & */) {
+      ENTITY_RE.lastIndex = index
+      const entity = ENTITY_RE.exec(text)
+      if (entity) {
+        const body = entity[1]!
+        if (body[0] === '#') {
+          const codepoint = body[1] === 'x' || body[1] === 'X'
+            ? Number.parseInt(body.slice(2), 16)
+            : Number.parseInt(body.slice(1), 10)
+          if (codepoint >= 0 && codepoint <= 0xFFFF) {
+            bmp[codepoint] = 1
+          }
+          else if (codepoint > 0xFFFF && codepoint <= 0x10FFFF) {
+            into.astral.add(codepoint)
+          }
+        }
+        else {
+          const decoded = NAMED_ENTITIES[body.toLowerCase()]
+          if (decoded) {
+            bmp[decoded.charCodeAt(0)] = 1
+          }
+          else {
+            into.complete = false
+          }
+        }
+        index = ENTITY_RE.lastIndex - 1
+        continue
+      }
+    }
+    if (code >= 0xD800 && code <= 0xDBFF && index + 1 < text.length) {
+      const low = text.charCodeAt(index + 1)
+      if (low >= 0xDC00 && low <= 0xDFFF) {
+        into.astral.add((code - 0xD800) * 0x400 + low - 0xDC00 + 0x10000)
+        index++
+        continue
+      }
+    }
+    bmp[code] = 1
+  }
+}
+
 /** Case-fold, unquote and unescape a single family name for comparison */
 export function normalizeFontFamily(family: string): string {
   let value = family.trim()

--- a/packages/beasties/src/index.ts
+++ b/packages/beasties/src/index.ts
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import type { ChildNode, Node } from 'domhandler'
+import type { ChildNode, Node, NodeWithChildren, Text } from 'domhandler'
 
 import type { HTMLDocument } from './dom'
 import type { Logger, Options } from './types'
@@ -25,7 +25,7 @@ import path from 'node:path'
 import { applyMarkedSelectors, markOnly, parseStylesheet, serializeStylesheet, validateMediaQuery, walkStyleRules, walkStyleRulesWithReverseMirror } from './css'
 import { CRITTERS_DEPRECATION_WARNING, parseDirective } from './directives'
 import { createDocument, serializeDocument } from './dom'
-import { normalizeFontFamily, parseFontFamilies } from './fonts'
+import { addTextCodepoints, createTextCodepoints, normalizeFontFamily, parseFontFamilies, parseUnicodeRanges, toCodepointSet, unicodeRangeUsed } from './fonts'
 import { isSafeMediaValue } from './media'
 import { isAlwaysCriticalSelector, isUnevaluableSelectorError, normalizeCssSelector } from './selectors'
 import { REMOTE_URL_RE, resolveCssUrl, rewriteCssUrls } from './urls'
@@ -34,6 +34,8 @@ import { createDeduplicatingLogger, createLogger, isSubpath } from './util'
 const LEADING_SLASH_OR_QUERY_RE = /^\/(?!\/)|[?#].*$/g
 const PUBLIC_PATH_RE = /(^\/(?!\/)|\/$)/g
 const FONT_PROP_RE = /^font(?:-family)?$/i
+const NON_RENDERED_ELEMENTS = new Set(['script', 'style', 'template', 'noscript', 'head', 'title'])
+const RENDERED_ATTRS = ['alt', 'label', 'placeholder', 'title', 'value']
 const LEADING_SLASH_RE = /^\//
 const WHITESPACE_RE = /\s+/
 // eslint-disable-next-line regexp/no-super-linear-backtracking,regexp/no-misleading-capturing-group
@@ -52,6 +54,7 @@ interface PreFetchedStylesheet {
 export default class Beasties {
   #selectorCache = new Map<string, string>()
   #preloadedFonts = new WeakMap<HTMLDocument, Set<string>>()
+  #documentChars = new WeakMap<HTMLDocument, Set<number> | undefined>()
   options: Options & Required<Pick<Options, 'logLevel' | 'path' | 'publicPath' | 'reduceInlineStyles' | 'pruneSource' | 'additionalStylesheets' | 'dedupeWarnings'>> & { allowRules: Array<string | RegExp> }
   logger: Logger
   fs?: typeof import('node:fs')
@@ -696,7 +699,7 @@ export default class Beasties {
                 continue
               }
               // detect used fonts
-              if (shouldInlineFonts && FONT_PROP_RE.test(decl.prop)) {
+              if ((shouldInlineFonts || shouldPreloadFonts) && FONT_PROP_RE.test(decl.prop)) {
                 for (const family of parseFontFamilies(decl.prop, decl.value)) {
                   criticalFonts.add(family)
                 }
@@ -754,7 +757,8 @@ export default class Beasties {
 
       // prune @font-face rules
       if (rule.type === 'atrule' && rule.name === 'font-face') {
-        let family, src
+        let family, src, ranges
+        let used = false
         if (rule.nodes) {
           for (const decl of rule.nodes) {
             if (!('prop' in decl)) {
@@ -767,9 +771,17 @@ export default class Beasties {
             else if (decl.prop === 'font-family') {
               family = decl.value
             }
+            else if (decl.prop === 'unicode-range') {
+              ranges = parseUnicodeRanges(decl.value)
+            }
           }
 
-          if (src && shouldPreloadFonts) {
+          used = !!family
+            && criticalFonts.has(normalizeFontFamily(family))
+            // reading the document's text is only worth it for a subsetted face
+            && (!ranges || unicodeRangeUsed(ranges, this.getDocumentChars(document)))
+
+          if (used && src && shouldPreloadFonts) {
             const href = style.$$name ? resolveCssUrl(src.trim(), style.$$name) : src.trim()
             if (!preloadedFonts.has(href)) {
               preloadedFonts.add(href)
@@ -783,13 +795,8 @@ export default class Beasties {
           }
         }
 
-        // if we're missing info, if the font is unused, or if critical font inlining is disabled, remove the rule:
-        // (`src` may be local()-only, as in metric-override fallback faces, so it isn't required)
-        if (
-          !shouldInlineFonts
-          || !family
-          || !criticalFonts.has(normalizeFontFamily(family))
-        ) {
+        // if the font is unused or critical font inlining is disabled, remove the rule
+        if (!shouldInlineFonts || !used) {
           return false
         }
       }
@@ -843,6 +850,44 @@ export default class Beasties {
     this.logger.info?.(
       `\u001B[32mInlined ${formatSize(sheet.length)} (${percent}% of original ${formatSize(before.length)}) of ${name}${afterText}.\u001B[39m`,
     )
+  }
+
+  /**
+   * Codepoints of a document's rendered text, or `undefined` when its text
+   * could not be read exactly, which disables `unicode-range` filtering.
+   */
+  private getDocumentChars(document: HTMLDocument): Set<number> | undefined {
+    if (this.#documentChars.has(document)) {
+      return this.#documentChars.get(document)
+    }
+    const text = createTextCodepoints()
+    // the whole document, not just beasties containers: text outside them is
+    // still rendered, and over-keeping a face is safer than dropping one
+    const queue: Node[] = [document as unknown as Node]
+    while (queue.length > 0) {
+      const node = queue.pop()!
+      if (node.type === 'text') {
+        addTextCodepoints((node as Text).data, text)
+        continue
+      }
+      if (node.type === 'tag') {
+        if (NON_RENDERED_ELEMENTS.has(node.nodeName.toLowerCase())) {
+          continue
+        }
+        for (const attr of RENDERED_ATTRS) {
+          const value = node.getAttribute(attr)
+          if (value) {
+            addTextCodepoints(value, text)
+          }
+        }
+      }
+      if ('children' in node) {
+        queue.push(...(node as NodeWithChildren).children as Node[])
+      }
+    }
+    const chars = toCodepointSet(text)
+    this.#documentChars.set(document, chars)
+    return chars
   }
 
   /**

--- a/packages/beasties/src/index.ts
+++ b/packages/beasties/src/index.ts
@@ -25,6 +25,7 @@ import path from 'node:path'
 import { applyMarkedSelectors, markOnly, parseStylesheet, serializeStylesheet, validateMediaQuery, walkStyleRules, walkStyleRulesWithReverseMirror } from './css'
 import { CRITTERS_DEPRECATION_WARNING, parseDirective } from './directives'
 import { createDocument, serializeDocument } from './dom'
+import { normalizeFontFamily, parseFontFamilies } from './fonts'
 import { isSafeMediaValue } from './media'
 import { isAlwaysCriticalSelector, isUnevaluableSelectorError, normalizeCssSelector } from './selectors'
 import { REMOTE_URL_RE, resolveCssUrl, rewriteCssUrls } from './urls'
@@ -32,7 +33,7 @@ import { createDeduplicatingLogger, createLogger, isSubpath } from './util'
 
 const LEADING_SLASH_OR_QUERY_RE = /^\/(?!\/)|[?#].*$/g
 const PUBLIC_PATH_RE = /(^\/(?!\/)|\/$)/g
-const FONT_FAMILY_RE = /\bfont(?:-family)?\b/i
+const FONT_PROP_RE = /^font(?:-family)?$/i
 const LEADING_SLASH_RE = /^\//
 const WHITESPACE_RE = /\s+/
 // eslint-disable-next-line regexp/no-super-linear-backtracking,regexp/no-misleading-capturing-group
@@ -568,8 +569,7 @@ export default class Beasties {
     const ast = parseStylesheet(sheet, { safeParser: this.options.safeParser !== false })
     const astInverse = options.pruneSource ? parseStylesheet(sheet, { safeParser: this.options.safeParser !== false }) : null
 
-    // a string to search for font names (very loose)
-    let criticalFonts = ''
+    const criticalFonts = new Set<string>()
 
     const unparseableSelectors: string[] = []
 
@@ -696,8 +696,10 @@ export default class Beasties {
                 continue
               }
               // detect used fonts
-              if (shouldInlineFonts && FONT_FAMILY_RE.test(decl.prop)) {
-                criticalFonts += ` ${decl.value}`
+              if (shouldInlineFonts && FONT_PROP_RE.test(decl.prop)) {
+                for (const family of parseFontFamilies(decl.prop, decl.value)) {
+                  criticalFonts.add(family)
+                }
               }
 
               // detect used keyframes
@@ -782,11 +784,11 @@ export default class Beasties {
         }
 
         // if we're missing info, if the font is unused, or if critical font inlining is disabled, remove the rule:
+        // (`src` may be local()-only, as in metric-override fallback faces, so it isn't required)
         if (
           !shouldInlineFonts
           || !family
-          || !src
-          || !criticalFonts.includes(family)
+          || !criticalFonts.has(normalizeFontFamily(family))
         ) {
           return false
         }

--- a/packages/beasties/src/plan-decode.ts
+++ b/packages/beasties/src/plan-decode.ts
@@ -67,10 +67,11 @@ function decodeRule(
     rule.keyframesUsed = derefAll(next<PooledString[]>())
   }
   if (flags & F_FONT_FACE) {
-    const [family, src] = next<[PooledString | 0, PooledString | 0]>()
+    const [family, src, ranges] = next<[PooledString | 0, PooledString | 0, number[]?]>()
     rule.fontFace = {
       family: family === 0 ? undefined : deref(family),
       src: src === 0 ? undefined : deref(src),
+      ranges,
     }
   }
   if (flags & F_KEYFRAMES) {

--- a/packages/beasties/src/plan-encode.ts
+++ b/packages/beasties/src/plan-encode.ts
@@ -174,10 +174,14 @@ function encodeRule(rule: CompiledRule, pool: StringPool, wrapKeys: Map<string, 
   }
   if (rule.fontFace) {
     flags |= F_FONT_FACE
-    fields.push([
+    const face: unknown[] = [
       rule.fontFace.family === undefined ? 0 : pool.ref(rule.fontFace.family),
       rule.fontFace.src === undefined ? 0 : pool.ref(rule.fontFace.src),
-    ])
+    ]
+    if (rule.fontFace.ranges) {
+      face.push(rule.fontFace.ranges)
+    }
+    fields.push(face)
   }
   if (rule.keyframes !== undefined) {
     flags |= F_KEYFRAMES

--- a/packages/beasties/src/runtime.ts
+++ b/packages/beasties/src/runtime.ts
@@ -10,7 +10,7 @@
 
 import type { AttrTest, CompiledRule, CompiledSheet, CompoundTest, SelectorMatch, StructuralProgram } from './compiler'
 import type { CompactPlan } from './plan'
-import { normalizeFontFamily } from './fonts'
+import { addTextCodepoints, createTextCodepoints, normalizeFontFamily, toCodepointSet, unicodeRangeUsed } from './fonts'
 import { isSafeMediaValue } from './media'
 import { isCompactPlan } from './plan'
 import { decodePlan } from './plan-decode'
@@ -23,6 +23,12 @@ export interface DocumentTokens {
   classes: Set<string>
   ids: Set<string>
   attrs: Set<string>
+  /**
+   * Codepoints of the document's rendered text, used to skip `@font-face`
+   * rules whose `unicode-range` covers no character in the document. Absent
+   * when the text could not be read exactly, which disables that check.
+   */
+  chars?: Set<number>
   /** Exact results for structural programs evaluated during the scan */
   matchedPrograms?: Map<StructuralProgram, boolean>
 }
@@ -45,6 +51,12 @@ const VOID_ELEMENTS = new Set([
 ])
 
 const RAW_TEXT_ELEMENTS = new Set(['script', 'style', 'textarea', 'title', 'xmp'])
+
+/** Raw text elements whose contents are still rendered as page text */
+const RENDERED_RAW_TEXT_ELEMENTS = new Set(['textarea', 'xmp'])
+
+/** Attributes whose value can be rendered as text */
+const RENDERED_ATTRS = new Set(['alt', 'label', 'placeholder', 'title', 'value'])
 
 const TAG_START_RE = /[a-z]/
 const TAG_NAME_END_RE = /[\s/>]/
@@ -235,10 +247,28 @@ function createFrame(container: boolean, desc: number[], child: number[]): ScanF
  * programs against it. If `data-beasties-container` elements are present,
  * only tokens (and program completions) within those subtrees count.
  */
-export function scanHtml(html: string, programs?: StructuralProgram[]): DocumentTokens {
+export interface ScanOptions {
+  /**
+   * Collect the codepoints of the document's text, which `@font-face` rules
+   * with a `unicode-range` are matched against. Skipping the walk is worth it
+   * when no compiled sheet has such a rule.
+   * @default true
+   */
+  chars?: boolean
+}
+
+export function scanHtml(html: string, programs?: StructuralProgram[], options: ScanOptions = {}): DocumentTokens {
+  const collectText = options.chars !== false
   const lower = html.toLowerCase()
   const all = createTokens()
   const contained = createTokens()
+
+  // an entity we can't decode means the document's text is not fully known, so
+  // `unicode-range` filtering has to be skipped rather than guess
+  const text = createTextCodepoints()
+  const collectChars = collectText
+    ? (run: string) => addTextCodepoints(run, text)
+    : () => {}
 
   const prepared = programs && programs.length > 0 ? preparePrograms(programs) : undefined
   const matchedAll = prepared ? Array.from<boolean>({ length: prepared.programs.length }).fill(false) : []
@@ -252,9 +282,14 @@ export function scanHtml(html: string, programs?: StructuralProgram[]): Document
   const length = html.length
 
   while (i < length) {
+    const textStart = i
     i = lower.indexOf('<', i)
     if (i === -1) {
+      collectChars(html.slice(textStart))
       break
+    }
+    if (i > textStart) {
+      collectChars(html.slice(textStart, i))
     }
 
     const next = lower[i + 1]
@@ -352,6 +387,9 @@ export function scanHtml(html: string, programs?: StructuralProgram[]): Document
 
       if (attrName) {
         element.attrs.push([attrName, value])
+        if (value !== null && RENDERED_ATTRS.has(attrName)) {
+          collectChars(value)
+        }
         if (attrName === 'data-beasties-container') {
           isContainer = true
           containerFound = true
@@ -448,12 +486,18 @@ export function scanHtml(html: string, programs?: StructuralProgram[]): Document
       if (close === -1) {
         break
       }
+      if (RENDERED_RAW_TEXT_ELEMENTS.has(tagName)) {
+        collectChars(html.slice(i, close))
+      }
       const end = lower.indexOf('>', close)
       i = end === -1 ? length : end + 1
     }
   }
 
   const tokens = containerFound ? contained : all
+  if (collectText) {
+    tokens.chars = toCodepointSet(text)
+  }
   if (prepared) {
     const matched = containerFound ? matchedContained : matchedAll
     tokens.matchedPrograms = new Map()
@@ -586,6 +630,9 @@ export interface RuntimeOptions {
   inlineFonts?: boolean
   /**
    * Preload critical fonts _(default: `true` when `fonts` is set)_
+   *
+   * Only faces whose family is declared by the critical CSS are preloaded, and
+   * a face with a `unicode-range` only when the document's text needs it.
    */
   preloadFonts?: boolean
   /**
@@ -635,10 +682,6 @@ export function renderCriticalCss(sheet: CompiledSheet, tokens: DocumentTokens, 
   for (let i = 0; i < rules.length; i++) {
     const rule = rules[i]!
     if (rule.fontFace) {
-      if (rule.fontFace.src && shouldPreloadFonts && !preloadedFonts.has(rule.fontFace.src)) {
-        preloadedFonts.add(rule.fontFace.src)
-        fontPreloads.push(rule.fontFace.src.trim())
-      }
       continue
     }
     if (rule.keyframes !== undefined) {
@@ -680,8 +723,15 @@ export function renderCriticalCss(sheet: CompiledSheet, tokens: DocumentTokens, 
       continue
     }
     if (rule.fontFace) {
-      const { family } = rule.fontFace
-      if (shouldInlineFonts && family && criticalFonts.has(normalizeFontFamily(family))) {
+      const { family, src, ranges } = rule.fontFace
+      const used = !!family
+        && criticalFonts.has(normalizeFontFamily(family))
+        && unicodeRangeUsed(ranges, tokens.chars)
+      if (used && src && shouldPreloadFonts && !preloadedFonts.has(src)) {
+        preloadedFonts.add(src)
+        fontPreloads.push(src.trim())
+      }
+      if (shouldInlineFonts && used) {
         texts[i] = rule.css ?? ''
       }
       else if (inverseTexts) {
@@ -825,6 +875,10 @@ function fingerprintTokens(tokens: DocumentTokens): string {
     }
     parts.push('\n')
   }
+  if (tokens.chars) {
+    parts.push(Array.from(tokens.chars).join(','))
+  }
+  parts.push('\n')
   if (tokens.matchedPrograms) {
     for (const matched of tokens.matchedPrograms.values()) {
       parts.push(matched ? '1' : '0')
@@ -981,6 +1035,9 @@ export function createProcessor(plans: Array<CompiledSheet | CompactPlan>, optio
 } {
   const sheets = plans.map(plan => (isCompactPlan(plan) ? decodePlan(plan) : plan))
   const programs = collectPrograms(sheets)
+  const scanOptions: ScanOptions = {
+    chars: sheets.some(sheet => sheet.rules.some(rule => rule.fontFace?.ranges)),
+  }
 
   const cacheSize = options.cache === false ? 0 : (typeof options.cache === 'object' ? options.cache.maxSize ?? DEFAULT_CACHE_SIZE : DEFAULT_CACHE_SIZE)
   const cache = cacheSize > 0 ? new Map<string, Map<CompiledSheet, CriticalResult>>() : undefined
@@ -1055,7 +1112,7 @@ export function createProcessor(plans: Array<CompiledSheet | CompactPlan>, optio
   }
 
   function extract(html: string): CriticalResult {
-    const tokens = scanHtml(html, programs)
+    const tokens = scanHtml(html, programs, scanOptions)
     const key = cache ? fingerprintTokens(tokens) : undefined
     const skipped = skippedSheets(html)
     const css: string[] = []
@@ -1072,7 +1129,7 @@ export function createProcessor(plans: Array<CompiledSheet | CompactPlan>, optio
   }
 
   function process(html: string, processOptions?: ProcessOptions): string {
-    const tokens = scanHtml(html, programs)
+    const tokens = scanHtml(html, programs, scanOptions)
     const key = cache ? fingerprintTokens(tokens) : undefined
     const strategy = options.preload
     const nonce = processOptions?.nonce ?? options.nonce

--- a/packages/beasties/src/runtime.ts
+++ b/packages/beasties/src/runtime.ts
@@ -10,6 +10,7 @@
 
 import type { AttrTest, CompiledRule, CompiledSheet, CompoundTest, SelectorMatch, StructuralProgram } from './compiler'
 import type { CompactPlan } from './plan'
+import { normalizeFontFamily } from './fonts'
 import { isSafeMediaValue } from './media'
 import { isCompactPlan } from './plan'
 import { decodePlan } from './plan-decode'
@@ -625,7 +626,7 @@ export function renderCriticalCss(sheet: CompiledSheet, tokens: DocumentTokens, 
     ? Array.from<string | null>({ length: rules.length }).fill(null)
     : undefined
 
-  let criticalFonts = ''
+  const criticalFonts = new Set<string>()
   const criticalKeyframeNames = new Set<string>()
   const fontPreloads: string[] = []
   const preloadedFonts = new Set<string>()
@@ -654,7 +655,9 @@ export function renderCriticalCss(sheet: CompiledSheet, tokens: DocumentTokens, 
     texts[i] = text
 
     if (rule.fontsUsed) {
-      criticalFonts += ` ${rule.fontsUsed.join(' ')}`
+      for (const family of rule.fontsUsed) {
+        criticalFonts.add(normalizeFontFamily(family))
+      }
     }
     if (rule.keyframesUsed) {
       for (const name of rule.keyframesUsed) {
@@ -677,8 +680,8 @@ export function renderCriticalCss(sheet: CompiledSheet, tokens: DocumentTokens, 
       continue
     }
     if (rule.fontFace) {
-      const { family, src } = rule.fontFace
-      if (shouldInlineFonts && family && src && criticalFonts.includes(family)) {
+      const { family } = rule.fontFace
+      if (shouldInlineFonts && family && criticalFonts.has(normalizeFontFamily(family))) {
         texts[i] = rule.css ?? ''
       }
       else if (inverseTexts) {

--- a/packages/beasties/src/types.ts
+++ b/packages/beasties/src/types.ts
@@ -84,6 +84,9 @@ export interface Options {
   inlineFonts?: boolean
   /**
    * Preloads critical fonts _(default: `true`)_
+   *
+   * Only faces whose family is declared by the critical CSS are preloaded, and
+   * a face with a `unicode-range` only when the document's text needs it.
    */
   preloadFonts?: boolean
   /**

--- a/packages/beasties/test/compiled.test.ts
+++ b/packages/beasties/test/compiled.test.ts
@@ -182,6 +182,22 @@ describe('compiled beasties (compiler + runtime)', () => {
       expect(compiled).not.toContain('UnusedFont')
     })
 
+    it('matches for unicode-range subsetting and escaped fallback families', async () => {
+      const css = trim`
+        h1 { font-family: Barlow, "Barlow Fallback: Segoe UI", sans-serif; }
+        @font-face { font-family: Barlow; src: url(/fonts/latin.woff2); unicode-range: U+0000-00FF; }
+        @font-face { font-family: Barlow; src: url(/fonts/vietnamese.woff2); unicode-range: U+1EA0-1EF9; }
+        @font-face { font-family: Barlow Fallback\\: Segoe UI; src: local(Segoe UI); size-adjust: 105.1%; }
+      `
+      const options = { inlineFonts: true, preloadFonts: false }
+      const classic = await classicCritical(BASIC_HTML, css, options)
+      const compiled = compiledCritical(BASIC_HTML, css, options)
+      expect(compiled).toBe(classic)
+      expect(compiled).toContain('/fonts/latin.woff2')
+      expect(compiled).not.toContain('/fonts/vietnamese.woff2')
+      expect(compiled).toContain('Barlow Fallback\\: Segoe UI')
+    })
+
     it('matches for pseudo-class and pseudo-element selectors', async () => {
       const css = trim`
         h1:hover { color: red; }

--- a/packages/beasties/test/fonts.test.ts
+++ b/packages/beasties/test/fonts.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+import { compileSheet } from '../src/compiler'
+import { parseFontFamilies } from '../src/fonts'
+import { collectPrograms, renderCriticalCss, scanHtml } from '../src/runtime'
+
+const NUXT_FONTS_CSS = `
+@font-face{font-family:Barlow;src:local(Barlow Regular Italic),local(Barlow Italic),url(/_fonts/Nkd.woff2)format("woff2");font-display:swap;unicode-range:U+0102-0103,U+1EA0-1EF9;font-weight:400;font-style:italic}
+@font-face{font-family:Barlow Fallback\\: BlinkMacSystemFont;src:local(BlinkMacSystemFont);size-adjust:103.48%;ascent-override:96.6366%;descent-override:19.3273%;line-gap-override:0%}
+@font-face{font-family:Barlow Fallback\\: Segoe UI;src:local(Segoe UI);size-adjust:105.1%}
+@font-face{font-family:Unused;src:url(/_fonts/unused.woff2)format("woff2")}
+@font-face{font-family:Unused Fallback\\: Segoe UI;src:local(Segoe UI);size-adjust:100%}
+.font-sans{font-family:Barlow,"Barlow Fallback: BlinkMacSystemFont","Barlow Fallback: Segoe UI",sans-serif}
+`
+
+const HTML = '<html><head><link rel="stylesheet" href="/style.css"></head><body><p class="font-sans">hi</p></body></html>'
+
+function critical(css: string, html: string, options = {}) {
+  const sheet = compileSheet(css, {})
+  return renderCriticalCss(sheet, scanHtml(html, collectPrograms([sheet])), options).css
+}
+
+describe('parseFontFamilies', () => {
+  it('should split family stacks into individual normalised families', () => {
+    expect(parseFontFamilies('font-family', 'Barlow, "Barlow Fallback: BlinkMacSystemFont", sans-serif'))
+      .toEqual(['barlow', 'barlow fallback: blinkmacsystemfont', 'sans-serif'])
+  })
+
+  it('should collect only the family list from a `font` shorthand', () => {
+    expect(parseFontFamilies('font', 'italic small-caps bold 400 16px/1.5 Barlow, system-ui'))
+      .toEqual(['barlow', 'system-ui'])
+    expect(parseFontFamilies('font', 'normal normal 16px / 1.5 ui-sans-serif, "Apple Color Emoji"'))
+      .toEqual(['ui-sans-serif', 'apple color emoji'])
+    expect(parseFontFamilies('font', 'x-large Barlow')).toEqual(['barlow'])
+  })
+
+  it('should yield no families for css-wide keywords and system font shorthands', () => {
+    expect(parseFontFamilies('font', 'inherit')).toEqual([])
+    expect(parseFontFamilies('font', 'caption')).toEqual([])
+    expect(parseFontFamilies('font-family', 'inherit')).toEqual([])
+  })
+})
+
+describe('@font-face inlining', () => {
+  it('should parse family and src for @nuxt/fonts-shaped faces', () => {
+    const faces = compileSheet(NUXT_FONTS_CSS, {}).rules.filter(rule => rule.fontFace).map(rule => rule.fontFace)
+    expect(faces.slice(0, 3)).toEqual([
+      { family: 'Barlow', src: '/_fonts/Nkd.woff2' },
+      { family: 'Barlow Fallback\\: BlinkMacSystemFont', src: undefined },
+      { family: 'Barlow Fallback\\: Segoe UI', src: undefined },
+    ])
+  })
+
+  it('should record only families in `fontsUsed`', () => {
+    const sheet = compileSheet('html{font:normal normal 16px/1.5 ui-sans-serif,system-ui}h1{font:inherit}b{font-weight:bolder}.font-sans{font-family:Barlow,"Barlow Fallback: Segoe UI"}', {})
+    expect(sheet.rules.map(rule => rule.fontsUsed)).toEqual([
+      ['ui-sans-serif', 'system-ui'],
+      undefined,
+      undefined,
+      ['barlow', 'barlow fallback: segoe ui'],
+    ])
+  })
+
+  it('should inline used faces including escaped metric-override fallbacks', () => {
+    const css = critical(NUXT_FONTS_CSS, HTML, { inlineFonts: true })
+    expect(css).toContain('font-family:Barlow;')
+    expect(css).toContain('Barlow Fallback\\: BlinkMacSystemFont')
+    expect(css).toContain('Barlow Fallback\\: Segoe UI')
+    expect(css).not.toContain('font-family:Unused')
+    expect(css).not.toContain('Unused Fallback')
+  })
+
+  it('should not match a family as a substring of a used family', () => {
+    const css = critical('@font-face{font-family:Sans;src:url(/sans.woff2)}.a{font-family:"Open Sans"}', '<html><body><p class="a">hi</p></body></html>', { inlineFonts: true })
+    expect(css).not.toContain('@font-face')
+  })
+})

--- a/packages/beasties/test/fonts.test.ts
+++ b/packages/beasties/test/fonts.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
 import { compileSheet } from '../src/compiler'
-import { parseFontFamilies } from '../src/fonts'
+import { parseFontFamilies, parseUnicodeRanges } from '../src/fonts'
+import Beasties from '../src/index'
 import { collectPrograms, renderCriticalCss, scanHtml } from '../src/runtime'
 
 const NUXT_FONTS_CSS = `
-@font-face{font-family:Barlow;src:local(Barlow Regular Italic),local(Barlow Italic),url(/_fonts/Nkd.woff2)format("woff2");font-display:swap;unicode-range:U+0102-0103,U+1EA0-1EF9;font-weight:400;font-style:italic}
+@font-face{font-family:Barlow;src:local(Barlow Regular Italic),local(Barlow Italic),url(/_fonts/latin.woff2)format("woff2");font-display:swap;unicode-range:U+0000-00FF,U+0131,U+2000-206F;font-weight:400;font-style:italic}
+@font-face{font-family:Barlow;src:local(Barlow Regular Italic),url(/_fonts/vietnamese.woff2)format("woff2");font-display:swap;unicode-range:U+0102-0103,U+1EA0-1EF9;font-weight:400;font-style:italic}
 @font-face{font-family:Barlow Fallback\\: BlinkMacSystemFont;src:local(BlinkMacSystemFont);size-adjust:103.48%;ascent-override:96.6366%;descent-override:19.3273%;line-gap-override:0%}
 @font-face{font-family:Barlow Fallback\\: Segoe UI;src:local(Segoe UI);size-adjust:105.1%}
 @font-face{font-family:Unused;src:url(/_fonts/unused.woff2)format("woff2")}
@@ -13,11 +15,13 @@ const NUXT_FONTS_CSS = `
 .font-sans{font-family:Barlow,"Barlow Fallback: BlinkMacSystemFont","Barlow Fallback: Segoe UI",sans-serif}
 `
 
-const HTML = '<html><head><link rel="stylesheet" href="/style.css"></head><body><p class="font-sans">hi</p></body></html>'
+function page(text: string) {
+  return `<html><head><link rel="stylesheet" href="/style.css"></head><body><p class="font-sans">${text}</p></body></html>`
+}
 
-function critical(css: string, html: string, options = {}) {
+function render(css: string, html: string, options = {}) {
   const sheet = compileSheet(css, {})
-  return renderCriticalCss(sheet, scanHtml(html, collectPrograms([sheet])), options).css
+  return renderCriticalCss(sheet, scanHtml(html, collectPrograms([sheet])), options)
 }
 
 describe('parseFontFamilies', () => {
@@ -41,13 +45,27 @@ describe('parseFontFamilies', () => {
   })
 })
 
+describe('parseUnicodeRanges', () => {
+  it('should parse single codepoints, ranges and wildcards', () => {
+    expect(parseUnicodeRanges('U+26')).toEqual([0x26, 0x26])
+    expect(parseUnicodeRanges('U+0102-0103, U+1EA0-1EF9')).toEqual([0x102, 0x103, 0x1EA0, 0x1EF9])
+    expect(parseUnicodeRanges('U+4??')).toEqual([0x400, 0x4FF])
+  })
+
+  it('should bail out on values it cannot parse', () => {
+    expect(parseUnicodeRanges('U+FF-00')).toBeUndefined()
+    expect(parseUnicodeRanges('var(--range)')).toBeUndefined()
+    expect(parseUnicodeRanges('')).toBeUndefined()
+  })
+})
+
 describe('@font-face inlining', () => {
-  it('should parse family and src for @nuxt/fonts-shaped faces', () => {
+  it('should parse family, src and unicode-range for @nuxt/fonts-shaped faces', () => {
     const faces = compileSheet(NUXT_FONTS_CSS, {}).rules.filter(rule => rule.fontFace).map(rule => rule.fontFace)
     expect(faces.slice(0, 3)).toEqual([
-      { family: 'Barlow', src: '/_fonts/Nkd.woff2' },
-      { family: 'Barlow Fallback\\: BlinkMacSystemFont', src: undefined },
-      { family: 'Barlow Fallback\\: Segoe UI', src: undefined },
+      { family: 'Barlow', src: '/_fonts/latin.woff2', ranges: [0x0, 0xFF, 0x131, 0x131, 0x2000, 0x206F] },
+      { family: 'Barlow', src: '/_fonts/vietnamese.woff2', ranges: [0x102, 0x103, 0x1EA0, 0x1EF9] },
+      { family: 'Barlow Fallback\\: BlinkMacSystemFont', src: undefined, ranges: undefined },
     ])
   })
 
@@ -62,8 +80,8 @@ describe('@font-face inlining', () => {
   })
 
   it('should inline used faces including escaped metric-override fallbacks', () => {
-    const css = critical(NUXT_FONTS_CSS, HTML, { inlineFonts: true })
-    expect(css).toContain('font-family:Barlow;')
+    const { css } = render(NUXT_FONTS_CSS, page('hi'), { inlineFonts: true })
+    expect(css).toContain('/_fonts/latin.woff2')
     expect(css).toContain('Barlow Fallback\\: BlinkMacSystemFont')
     expect(css).toContain('Barlow Fallback\\: Segoe UI')
     expect(css).not.toContain('font-family:Unused')
@@ -71,7 +89,97 @@ describe('@font-face inlining', () => {
   })
 
   it('should not match a family as a substring of a used family', () => {
-    const css = critical('@font-face{font-family:Sans;src:url(/sans.woff2)}.a{font-family:"Open Sans"}', '<html><body><p class="a">hi</p></body></html>', { inlineFonts: true })
+    const { css } = render('@font-face{font-family:Sans;src:url(/sans.woff2)}.a{font-family:"Open Sans"}', '<html><body><p class="a">hi</p></body></html>', { inlineFonts: true })
     expect(css).not.toContain('@font-face')
+  })
+})
+
+describe('unicode-range filtering', () => {
+  it('should skip faces whose subset covers no character in the document', () => {
+    const { css } = render(NUXT_FONTS_CSS, page('hi'), { inlineFonts: true })
+    expect(css).toContain('/_fonts/latin.woff2')
+    expect(css).not.toContain('/_fonts/vietnamese.woff2')
+  })
+
+  it('should keep a subset once the document uses it', () => {
+    const { css } = render(NUXT_FONTS_CSS, page('xin ch&#7845;o'), { inlineFonts: true })
+    expect(css).toContain('/_fonts/vietnamese.woff2')
+  })
+
+  it('should keep every subset when the document text cannot be decoded', () => {
+    const { css } = render(NUXT_FONTS_CSS, page('xin ch&agrave;o'), { inlineFonts: true })
+    expect(css).toContain('/_fonts/vietnamese.woff2')
+  })
+
+  it('should count text in rendered attributes', () => {
+    const html = '<html><body><p class="font-sans"><input value="\u1EA1"></p></body></html>'
+    const { css } = render(NUXT_FONTS_CSS, html, { inlineFonts: true })
+    expect(css).toContain('/_fonts/vietnamese.woff2')
+  })
+})
+
+describe('font preloading', () => {
+  it('should only preload faces used by the critical css', () => {
+    const { fontPreloads } = render(NUXT_FONTS_CSS, page('hi'), { preloadFonts: true })
+    expect(fontPreloads).toEqual(['/_fonts/latin.woff2'])
+  })
+
+  it('should preload a subset once the document uses it', () => {
+    const { fontPreloads } = render(NUXT_FONTS_CSS, page('xin ch\u1EA5o'), { preloadFonts: true })
+    expect(fontPreloads).toEqual(['/_fonts/latin.woff2', '/_fonts/vietnamese.woff2'])
+  })
+})
+
+describe('font preloading via process()', () => {
+  const CSS = [
+    'h1 { font-family: Barlow, sans-serif; }',
+    '.unused { font-family: Other; }',
+    '@font-face { font-family: Barlow; src: url(/fonts/latin.woff2); unicode-range: U+0000-00FF; }',
+    '@font-face { font-family: Barlow; src: url(/fonts/vietnamese.woff2); unicode-range: U+1EA0-1EF9; }',
+    '@font-face { font-family: Other; src: url(/fonts/other.woff2); }',
+  ].join('\n')
+
+  async function process(body: string) {
+    const beasties = new Beasties({ reduceInlineStyles: false, path: '/', logLevel: 'silent', preload: false, preloadFonts: true, inlineFonts: true })
+    beasties.readFile = () => CSS
+    return beasties.process(`<html><head><link rel="stylesheet" href="/style.css"></head><body>${body}</body></html>`)
+  }
+
+  it('should preload only the faces used by the critical css', async () => {
+    const result = await process('<h1>Hello</h1>')
+    expect(result).toContain('href="/fonts/latin.woff2"')
+    expect(result).not.toContain('href="/fonts/vietnamese.woff2"')
+    expect(result).not.toContain('href="/fonts/other.woff2"')
+  })
+
+  it('should preload and inline a subset once the document uses it', async () => {
+    const result = await process('<h1>xin ch\u1EA5o</h1>')
+    expect(result).toContain('href="/fonts/vietnamese.woff2"')
+    expect(result).toContain('url(/fonts/vietnamese.woff2)')
+  })
+})
+
+describe('unicode-range filtering via process()', () => {
+  const CSS = [
+    'h1 { font-family: Barlow; }',
+    '@font-face { font-family: Barlow; src: url(/fonts/latin.woff2); unicode-range: U+0000-00FF; }',
+    '@font-face { font-family: Barlow; src: url(/fonts/greek.woff2); unicode-range: U+0370-03FF; }',
+  ].join('\n')
+
+  async function process(html: string) {
+    const beasties = new Beasties({ reduceInlineStyles: false, path: '/', logLevel: 'silent', preload: false, inlineFonts: true, preloadFonts: false })
+    beasties.readFile = () => CSS
+    return beasties.process(html)
+  }
+
+  it('should ignore text in script and style elements', async () => {
+    const result = await process(`<html><head><link rel="stylesheet" href="/style.css"><style>.x{content:"\u03B1"}</style><script>const a = '\u03B1'</script></head><body><h1>Hello</h1></body></html>`)
+    expect(result).toContain('url(/fonts/latin.woff2)')
+    expect(result).not.toContain('url(/fonts/greek.woff2)')
+  })
+
+  it('should count text in the document body', async () => {
+    const result = await process('<html><head><link rel="stylesheet" href="/style.css"></head><body><h1>\u03BA\u03B1\u03BB\u03AE\u03BC\u03AD\u03C1\u03B1</h1></body></html>')
+    expect(result).toContain('url(/fonts/greek.woff2)')
   })
 })


### PR DESCRIPTION
this bundles two fixes:
- do not preload fonts or subsets that are not actually used in the html
- normalise font families so they match despite quotes/escapes/case differences...
